### PR TITLE
Remove dep and use go modules in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: xenial
 language: go
 
 go:
-- 1.9.x
+- 1.11.x
 - 1.13.x
 
 go_import_path: "github.com/pterodactyl/wings"
@@ -18,8 +18,6 @@ install:
 - go get github.com/mitchellh/gox
 - go get github.com/haya14busa/goverage
 - go get github.com/schrej/godacov
-
-- go mod download
 
 script:
 - make cross-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,25 @@
+os: linux
+dist: xenial
 language: go
 
 go:
 - 1.9.x
+- 1.13.x
+
+go_import_path: "github.com/pterodactyl/wings"
 
 services:
-  - docker
+- docker
 
 install:
 - mkdir -p $GOPATH/bin
 
 # Install used tools
-- go get github.com/golang/dep/cmd/dep
 - go get github.com/mitchellh/gox
 - go get github.com/haya14busa/goverage
 - go get github.com/schrej/godacov
 
-# Install project dependencies with dep
-- dep ensure
+- go mod download
 
 script:
 - make cross-build


### PR DESCRIPTION
Should fix the Travis CI build errors and adds testing for go1.13