### PR TITLE
Update config.yml location

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,7 +19,7 @@ import (
 	"sync"
 )
 
-const DefaultLocation = "/var/lib/pterodactyl/config.yml"
+const DefaultLocation = "/srv/wings/config.yml"
 
 type Configuration struct {
 	sync.RWMutex `json:"-" yaml:"-"`

--- a/config/config.go
+++ b/config/config.go
@@ -19,7 +19,7 @@ import (
 	"sync"
 )
 
-const DefaultLocation = "/srv/wings/config.yml"
+const DefaultLocation = "/etc/wings/config.yml"
 
 type Configuration struct {
 	sync.RWMutex `json:"-" yaml:"-"`


### PR DESCRIPTION
Changed the config.yml location from /var/lib/pterodactyl/config.yml to /srv/wings/config.yml (Most users are used to the config file being in the /srv/wings folder rather than the /var/lib/pterodactyl folder)