### PR TITLE
Added network option to docker configuration

### DIFF
--- a/config/config_docker.go
+++ b/config/config_docker.go
@@ -26,6 +26,7 @@ type DockerNetworkConfiguration struct {
 	Name       string                  `default:"pterodactyl_nw"`
 	ISPN       bool                    `default:"false" yaml:"ispn"`
 	Driver     string                  `default:"bridge"`
+	Mode       string                  `default:"pterodactyl_nw" yaml:"network_mode"`
 	IsInternal bool                    `default:"false" yaml:"is_internal"`
 	EnableICC  bool                    `default:"true" yaml:"enable_icc"`
 	Interfaces dockerNetworkInterfaces `yaml:"interfaces"`

--- a/server/environment_docker.go
+++ b/server/environment_docker.go
@@ -665,7 +665,7 @@ func (d *DockerEnvironment) Create() error {
 			"setpcap", "mknod", "audit_write", "net_raw", "dac_override",
 			"fowner", "fsetid", "net_bind_service", "sys_chroot", "setfcap",
 		},
-		NetworkMode: "pterodactyl_nw",
+		NetworkMode: container.NetworkMode(config.Get().Docker.Network.Mode),
 	}
 
 	if _, err := cli.ContainerCreate(ctx, conf, hostConf, nil, d.Server.Uuid); err != nil {


### PR DESCRIPTION
Hello,

I'm using this option myself and I really need it in the future.
I know some other people (mostly people with GRE Tunnel etc) which needs the option too.
The old daemon had this option too, but wings still don't have it.

(also I'm not a go developer so ... yeah I'm not sure if I've done everything right - at least it's working for me)