### PR TITLE
Send disk usage when server is offline

### DIFF
--- a/router/websocket/websocket.go
+++ b/router/websocket/websocket.go
@@ -1,6 +1,7 @@
 package websocket
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/gbrlsnchs/jwt/v3"
 	"github.com/google/uuid"
@@ -223,14 +224,39 @@ func (h *Handler) HandleInbound(m Message) error {
 				h.setJwt(token)
 			}
 
-			// On every authentication event, send the current server status back
-			// to the client. :)
-			h.server.Events().Publish(server.StatusEvent, h.server.GetState())
-
 			h.unsafeSendJson(Message{
 				Event: AuthenticationSuccessEvent,
 				Args:  []string{},
 			})
+
+			// On every authentication event, send the current server status back
+			// to the client. :)
+			state := h.server.GetState()
+			h.SendJson(&Message{
+				Event: server.StatusEvent,
+				Args:  []string{state},
+			})
+
+			// Only send the current disk usage if the server is offline, if docker container is running,
+			// Environment#EnableResourcePolling() will send this data to all clients.
+			if state == server.ProcessOfflineState {
+				_ = h.server.Filesystem.HasSpaceAvailable()
+
+				resources := server.ResourceUsage{
+					Memory:      0,
+					MemoryLimit: 0,
+					CpuAbsolute: 0.0,
+					Disk:        h.server.Resources.Disk,
+				}
+				resources.Network.RxBytes = 0
+				resources.Network.TxBytes = 0
+
+				b, _ := json.Marshal(resources)
+				h.SendJson(&Message{
+					Event: server.StatsEvent,
+					Args:  []string{string(b)},
+				})
+			}
 
 			return nil
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -247,6 +247,10 @@ func FromConfiguration(data *api.ServerConfigurationResponse) (*Server, error) {
 	}
 	s.Resources = ResourceUsage{}
 
+	// Force the disk usage to become cached to return in a resources response
+	// or when connecting to the websocket of an offline server.
+	go s.Filesystem.HasSpaceAvailable()
+
 	// Forces the configuration to be synced with the panel.
 	if err := s.SyncWithConfiguration(data); err != nil {
 		return nil, err


### PR DESCRIPTION
Sends the disk usage in the stats event upon connecting to the websocket when a server is offline, this forces the disk usage to be calculated when a server is loaded when wings is started.

Also fixes an issue where the status event would be send to all clients when a new person connects.

Closes pterodactyl/panel#1796