### PR TITLE
#2078 - fix BindJSON calls

### DIFF
--- a/router/router_server.go
+++ b/router/router_server.go
@@ -46,7 +46,10 @@ func postServerPower(c *gin.Context) {
 	s := GetServer(c.Param("server"))
 
 	var data server.PowerAction
-	c.BindJSON(&data)
+	// BindJSON sends 400 if the request fails, all we need to do is return
+	if err := c.BindJSON(&data); err != nil {
+		return
+	}
 
 	if !data.IsValid() {
 		c.AbortWithStatusJSON(http.StatusUnprocessableEntity, gin.H{
@@ -98,8 +101,13 @@ func postServerCommands(c *gin.Context) {
 		return
 	}
 
-	var data struct{ Commands []string `json:"commands"` }
-	c.BindJSON(&data)
+	var data struct {
+		Commands []string `json:"commands"`
+	}
+	// BindJSON sends 400 if the request fails, all we need to do is return
+	if err := c.BindJSON(&data); err != nil {
+		return
+	}
 
 	for _, command := range data.Commands {
 		if err := s.Environment.SendCommand(command); err != nil {

--- a/router/router_server_backup.go
+++ b/router/router_server_backup.go
@@ -15,7 +15,10 @@ func postServerBackup(c *gin.Context) {
 	s := GetServer(c.Param("server"))
 
 	data := &backup.Request{}
-	c.BindJSON(&data)
+	// BindJSON sends 400 if the request fails, all we need to do is return
+	if err := c.BindJSON(&data); err != nil {
+		return
+	}
 
 	var adapter backup.BackupInterface
 	var err error
@@ -40,7 +43,6 @@ func postServerBackup(c *gin.Context) {
 			zap.S().Errorw("failed to generate backup for server", zap.Error(err))
 		}
 	}(adapter, s)
-
 
 	c.Status(http.StatusAccepted)
 }

--- a/router/router_server_files.go
+++ b/router/router_server_files.go
@@ -89,7 +89,10 @@ func putServerRenameFile(c *gin.Context) {
 		RenameFrom string `json:"rename_from"`
 		RenameTo   string `json:"rename_to"`
 	}
-	c.BindJSON(&data)
+	// BindJSON sends 400 if the request fails, all we need to do is return
+	if err := c.BindJSON(&data); err != nil {
+		return
+	}
 
 	if data.RenameFrom == "" || data.RenameTo == "" {
 		c.AbortWithStatusJSON(http.StatusUnprocessableEntity, gin.H{
@@ -113,7 +116,10 @@ func postServerCopyFile(c *gin.Context) {
 	var data struct {
 		Location string `json:"location"`
 	}
-	c.BindJSON(&data)
+	// BindJSON sends 400 if the request fails, all we need to do is return
+	if err := c.BindJSON(&data); err != nil {
+		return
+	}
 
 	if err := s.Filesystem.Copy(data.Location); err != nil {
 		TrackedServerError(err, s).AbortWithServerError(c)
@@ -130,7 +136,10 @@ func postServerDeleteFile(c *gin.Context) {
 	var data struct {
 		Location string `json:"location"`
 	}
-	c.BindJSON(&data)
+	// BindJSON sends 400 if the request fails, all we need to do is return
+	if err := c.BindJSON(&data); err != nil {
+		return
+	}
 
 	if err := s.Filesystem.Delete(data.Location); err != nil {
 		TrackedServerError(err, s).AbortWithServerError(c)
@@ -167,7 +176,10 @@ func postServerCreateDirectory(c *gin.Context) {
 		Name string `json:"name"`
 		Path string `json:"path"`
 	}
-	c.BindJSON(&data)
+	// BindJSON sends 400 if the request fails, all we need to do is return
+	if err := c.BindJSON(&data); err != nil {
+		return
+	}
 
 	if err := s.Filesystem.CreateDirectory(data.Name, data.Path); err != nil {
 		TrackedServerError(err, s).AbortWithServerError(c)

--- a/router/router_system.go
+++ b/router/router_system.go
@@ -77,7 +77,10 @@ func postUpdateConfiguration(c *gin.Context) {
 	// A copy of the configuration we're using to bind the data recevied into.
 	cfg := *config.Get()
 
-	c.BindJSON(&cfg)
+	// BindJSON sends 400 if the request fails, all we need to do is return
+	if err := c.BindJSON(&cfg); err != nil {
+		return
+	}
 
 	config.Set(&cfg)
 	if err := config.Get().WriteToDisk(); err != nil {


### PR DESCRIPTION
This PR addresses https://github.com/pterodactyl/panel/issues/2078.

---

From the issues description:

Gin's `BindJSON` method returns `error`. According to the documentation, `BindJSON` wraps `MustBindWith`, which in turn results in a 400 should any parsing errors occur.

While this works out of the box and will stop any middleware chains, it will not return from the current function (the function calling `BindJSON`). This must be done manually.

This would be a working example:
```golang
// BindJSON sends 400 if the request fails, all we need to do is return
if err := c.BindJSON(&data); err != nil {
  return
}
```

Wings currently has eight references to `BindJSON`:
- `router/router_server_backup.go:18`
- `router/server.go:49`
- `router/server.go:102`
- `router/router_server_files.go:92`
- `router/router_server_files.go:116`
- `router/router_server_files.go:133`
- `router/router_server_files.go:170`
- `router/router_system.go:80`