### PR TITLE
Fix a possible race condition when Unsubscribing from the EventBus

### DIFF
--- a/router/websocket/listeners.go
+++ b/router/websocket/listeners.go
@@ -26,9 +26,9 @@ func (h *Handler) ListenForExpiration(ctx context.Context) {
 			jwt := h.GetJwt()
 			if jwt != nil {
 				if jwt.ExpirationTime.Unix()-time.Now().Unix() <= 0 {
-					h.SendJson(&Message{Event: TokenExpiredEvent})
+					_ = h.SendJson(&Message{Event: TokenExpiredEvent})
 				} else if jwt.ExpirationTime.Unix()-time.Now().Unix() <= 180 {
-					h.SendJson(&Message{Event: TokenExpiringEvent})
+					_ = h.SendJson(&Message{Event: TokenExpiringEvent})
 				}
 			}
 		}
@@ -63,7 +63,7 @@ func (h *Handler) ListenForServerEvents(ctx context.Context) {
 
 			close(eventChannel)
 		default:
-			h.SendJson(&Message{
+			_ = h.SendJson(&Message{
 				Event: d.Topic,
 				Args:  []string{d.Data},
 			})


### PR DESCRIPTION
Whenever an event is published the current implementation spawns a go-routine which handles sending to all the registered channels for that event.  This causes a problem as the spawned go-routine is not covered by the lock so if the channel is unsubscribed (and closed) after the data go-routine was spawned, the data attempting to be sent to the channel will cause a panic because the channel is closed.  This solves that problem by spawning a go-routine for all the publish logic instead of just sending to the channel.

Stacktrace:
```
panic: send on closed channel

goroutine 714 [running]:
github.com/pterodactyl/wings/server.(*EventBus).Publish.func1(0xc00003cda0, 0x1b, 0xf55cc6, 0xe, 0xc000598d40, 0x2, 0x2)
        wings/server/events.go:69 +0x6a
created by github.com/pterodactyl/wings/server.(*EventBus).Publish
        wings/server/events.go:67 +0x15c
panic: send on closed channel

goroutine 715 [running]:
github.com/pterodactyl/wings/server.(*EventBus).Publish.func1(0xc0005108c0, 0x31, 0xf55cc6, 0xe, 0xc000598d40, 0x2, 0x2)
        wings/server/events.go:69 +0x6a
created by github.com/pterodactyl/wings/server.(*EventBus).Publish
        wings/server/events.go:67 +0x15c
```