### PR TITLE
Add a upload file endpoint

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -35,6 +35,7 @@ func Configure() *gin.Engine {
 	// These routes use signed URLs to validate access to the resource being requested.
 	router.GET("/download/backup", getDownloadBackup)
 	router.GET("/download/file", getDownloadFile)
+	router.POST("/upload/file", postServerUploadFiles)
 
 	// This route is special it sits above all of the other requests because we are
 	// using a JWT to authorize access to it, therefore it needs to be publicly

--- a/router/router_server_files.go
+++ b/router/router_server_files.go
@@ -360,11 +360,9 @@ func postServerUploadFiles(c *gin.Context) {
 		return
 	}
 
-	// TODO: Make sure directory is safe.
 	directory := c.Query("directory")
 
 	for _, header := range headers {
-		// TODO: Make sure header#Filename is clean.
 		p, err := s.Filesystem.SafePath(filepath.Join(directory, header.Filename))
 		if err != nil {
 			c.AbortWithError(http.StatusInternalServerError, err)
@@ -381,16 +379,6 @@ func postServerUploadFiles(c *gin.Context) {
 }
 
 func handleFileUpload(p string, s *server.Server, header *multipart.FileHeader) error {
-	_, err := s.Filesystem.Stat(header.Filename)
-	if err == nil {
-		// TODO: Figure out how to better handle this
-
-		// This means the file exists, not 100% sure what to do in this situation, but for now we will skip the file.
-		return nil
-	} else if !os.IsNotExist(err) {
-		return errors.WithStack(err)
-	}
-
 	file, err := header.Open()
 	if err != nil {
 		return errors.WithStack(err)

--- a/router/tokens/upload.go
+++ b/router/tokens/upload.go
@@ -4,16 +4,15 @@ import (
 	"github.com/gbrlsnchs/jwt/v3"
 )
 
-type BackupPayload struct {
+type UploadPayload struct {
 	jwt.Payload
 
 	ServerUuid string `json:"server_uuid"`
-	BackupUuid string `json:"backup_uuid"`
 	UniqueId   string `json:"unique_id"`
 }
 
 // Returns the JWT payload.
-func (p *BackupPayload) GetPayload() *jwt.Payload {
+func (p *UploadPayload) GetPayload() *jwt.Payload {
 	return &p.Payload
 }
 
@@ -21,6 +20,6 @@ func (p *BackupPayload) GetPayload() *jwt.Payload {
 // unique ID passed in the token has already been seen before this will
 // return false. This allows us to use this JWT as a one-time token that
 // validates all of the request.
-func (p *BackupPayload) IsUniqueRequest() bool {
+func (p *UploadPayload) IsUniqueRequest() bool {
 	return getTokenStore().IsValidToken(p.UniqueId)
 }


### PR DESCRIPTION
This adds the `/upload/file` endpoint which functions similarly to backup downloads except with a multipart body.

This is ready to be merged but some code review would be appreciated.