### PR TITLE
Force disk usage calculation when loading servers

### DIFF
--- a/server/loader.go
+++ b/server/loader.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/pterodactyl/wings/api"
 	"github.com/remeh/sizedwaitgroup"
+	"os"
 	"time"
 )
 
@@ -108,7 +109,12 @@ func FromConfiguration(data *api.ServerConfigurationResponse) (*Server, error) {
 		Server: s,
 	}
 	s.Filesystem = Filesystem{
-		Server:        s,
+		Server: s,
+	}
+
+	// If the server's data directory exists, force disk usage calculation.
+	if _, err := os.Stat(s.Filesystem.Path()); err == nil {
+		go s.Filesystem.HasSpaceAvailable()
 	}
 
 	// Forces the configuration to be synced with the panel.

--- a/server/server.go
+++ b/server/server.go
@@ -158,7 +158,7 @@ func (s *Server) GetProcessConfiguration() (*api.ServerConfigurationResponse, *a
 	return api.NewRequester().GetServerConfiguration(s.Id())
 }
 
-// Helper function that can receieve a power action and then process the
+// Helper function that can receive a power action and then process the
 // actions that need to occur for it.
 func (s *Server) HandlePowerAction(action PowerAction) error {
 	switch action.Action {


### PR DESCRIPTION
This was originally implemented in https://github.com/pterodactyl/wings/pull/32 but this broke when a new server was being installed and was reverted (https://github.com/pterodactyl/wings/commit/a3d83d23bdde2907a93ce70b48abd22728c84d7b).  This PR re-implements the original behavior but checks that the server's data directory actually exists before attempting to calculate it.