### PR TITLE
Fix race condition on startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build:
-	GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -gcflags "all=-trimpath=/Users/dane/Sites/development/code" -o build/wings_linux_amd64 -v wings.go
+	GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -gcflags "all=-trimpath=$(PWD)" -o build/wings_linux_amd64 -v wings.go
 
 compress:
 	upx --brute build/wings_*

--- a/server/loader.go
+++ b/server/loader.go
@@ -104,14 +104,14 @@ func FromConfiguration(data *api.ServerConfigurationResponse) (*Server, error) {
 		Server: s,
 	}
 
-	// If the server's data directory exists, force disk usage calculation.
-	if _, err := os.Stat(s.Filesystem.Path()); err == nil {
-		go s.Filesystem.HasSpaceAvailable()
-	}
-
 	// Forces the configuration to be synced with the panel.
 	if err := s.SyncWithConfiguration(data); err != nil {
 		return nil, err
+	}
+
+	// If the server's data directory exists, force disk usage calculation.
+	if _, err := os.Stat(s.Filesystem.Path()); err == nil {
+		go s.Filesystem.HasSpaceAvailable()
 	}
 
 	return s, nil


### PR DESCRIPTION
This also changes the `Makefile` to use the current build directory when stripping paths.