### PR TITLE
Inform user the daemon is checking disk size on server startup

### DIFF
--- a/server/power.go
+++ b/server/power.go
@@ -141,6 +141,7 @@ func (s *Server) onBeforeStart() error {
 	// and process resource limits are correctly applied.
 	s.SyncWithEnvironment()
 
+	s.PublishConsoleOutputFromDaemon("Checking server disk space usage, this could take a few seconds...")
 	if !s.Filesystem.HasSpaceAvailable() {
 		return errors.New("cannot start server, not enough disk space available")
 	}


### PR DESCRIPTION
When starting a server with a large amount of files, disk size checking takes a while and there's currently no feedback in the server console when it's doing the operation.

Currently daemon 0.7 informs the user the size operation is happening, this PR adds parity for this in 1.0.