### PR TITLE
Add log rotate template to wings docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,5 @@ RUN apk add --no-cache upx \
 
 FROM alpine:latest
 COPY --from=0 /go/wings/wings /usr/bin/
+COPY ./templates /templates
 CMD ["wings","--config", "/var/lib/pterodactyl/config.yml"]


### PR DESCRIPTION
Currently the docker image fails to run as it cant find the logrotate template file.
This change copies the template folder into the final image solving the problem.