### PR TITLE
Removed stray `.` in `./mnt/install`

### DIFF
--- a/server/install.go
+++ b/server/install.go
@@ -395,7 +395,7 @@ func (ip *InstallationProcess) Execute() (string, error) {
 		AttachStdin:  true,
 		OpenStdin:    true,
 		Tty:          true,
-		Cmd:          []string{ip.Script.Entrypoint, "./mnt/install/install.sh"},
+		Cmd:          []string{ip.Script.Entrypoint, "/mnt/install/install.sh"},
 		Image:        ip.Script.ContainerImage,
 		Env:          ip.Server.GetEnvironmentVariables(),
 		Labels: map[string]string{


### PR DESCRIPTION
This was preventing some install scripts from running, with an error stating that `./mnt/install/install.sh` does not exist.

Changing the working directory symbol (`./`) to root directory symbol (`/`) remedied this.