### PR TITLE
Insert UUID into container as envvar

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -84,6 +84,7 @@ func (s *Server) GetEnvironmentVariables() []string {
 		fmt.Sprintf("SERVER_MEMORY=%d", s.MemoryLimit()),
 		fmt.Sprintf("SERVER_IP=%s", s.Config().Allocations.DefaultMapping.Ip),
 		fmt.Sprintf("SERVER_PORT=%d", s.Config().Allocations.DefaultMapping.Port),
+		fmt.Sprintf("UUID=%s", s.Config().Uuid),
 	}
 
 eloop:


### PR DESCRIPTION
This change simply inserts the server's UUID into the container as an environment variable. This is useful for people such as myself for creating autoscaling systems with Pterodactyl, with which servers must know their own UUID.