### PR TITLE
Explictily disable log compression

### DIFF
--- a/environment/docker/container.go
+++ b/environment/docker/container.go
@@ -212,6 +212,7 @@ func (e *Environment) Create() error {
 			Config: map[string]string{
 				"max-size": "5m",
 				"max-file": "1",
+				"compress": "false",
 			},
 		},
 


### PR DESCRIPTION
Log compression is only relevant when `max-file` is 2 or higher.

Older versions of docker (Docker version 19.03.14, build 5eb3275d40 for example (currently the latest version on Debian 9)) error out when compression is enabled in the ``/etc/docker/daemon.json`` file:

```
Error response from daemon: failed to initialize logging driver: compress cannot be true when max-file is less than 2 or max-size is not set
```

While newer docker versions just don't care setting this explicitly to false like in ``intsall.go``, it doesn't hurt being explicit here:

https://github.com/pterodactyl/wings/blob/de51fd1c513a9504f2a19be52f216ea263aba56b/server/install.go#L481-L485

If possible it would be highly apprechiated if this could be released soon, as I am not experienced with building go binaries. But providing a custom build should work too.