### PR TITLE
Revert "Less obtuse logic for polling resource usage when attaching a container"

### DIFF
--- a/environment/docker/console.go
+++ b/environment/docker/console.go
@@ -1,0 +1,20 @@
+package docker	
+
+import "io"	
+
+type Console struct {	
+	HandlerFunc *func(string)	
+}	
+
+var _ io.Writer = Console{}	
+
+func (c Console) Write(b []byte) (int, error) {	
+	if c.HandlerFunc != nil {	
+		l := make([]byte, len(b))	
+		copy(l, b)	
+
+		(*c.HandlerFunc)(string(l))	
+	}	
+
+	return len(b), nil	
+}

--- a/environment/docker/console.go
+++ b/environment/docker/console.go
@@ -1,20 +1,20 @@
-package docker	
+package docker
 
-import "io"	
+import "io"
 
-type Console struct {	
-	HandlerFunc *func(string)	
-}	
+type Console struct {
+	HandlerFunc *func(string)
+}
 
-var _ io.Writer = Console{}	
+var _ io.Writer = Console{}
 
-func (c Console) Write(b []byte) (int, error) {	
-	if c.HandlerFunc != nil {	
-		l := make([]byte, len(b))	
-		copy(l, b)	
+func (c Console) Write(b []byte) (int, error) {
+	if c.HandlerFunc != nil {
+		l := make([]byte, len(b))
+		copy(l, b)
 
-		(*c.HandlerFunc)(string(l))	
-	}	
+		(*c.HandlerFunc)(string(l))
+	}
 
-	return len(b), nil	
+	return len(b), nil
 }

--- a/environment/docker/environment.go
+++ b/environment/docker/environment.go
@@ -2,7 +2,6 @@ package docker
 
 import (
 	"context"
-	"github.com/apex/log"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/pterodactyl/wings/api"
@@ -69,10 +68,6 @@ func New(id string, m *Metadata, c *environment.Configuration) (*Environment, er
 	}
 
 	return e, nil
-}
-
-func (e *Environment) log() *log.Entry {
-	return log.WithField("environment", e.Type()).WithField("container_id", e.Id)
 }
 
 func (e *Environment) Type() string {


### PR DESCRIPTION
This reverts commit https://github.com/pterodactyl/wings/commit/963a906c3091251bfedfd192c5b36107ae3af7d1.

It should be noted that this code is technically fine and there are no problems with it but due to an issue with moby this change broke some functionality for people.

Resolves https://github.com/pterodactyl/panel/issues/2986