### PR TITLE
Quote and escape Content-Disposition header

### DIFF
--- a/router/router_download.go
+++ b/router/router_download.go
@@ -52,7 +52,7 @@ func getDownloadBackup(c *gin.Context) {
 	defer f.Close()
 
 	c.Header("Content-Length", strconv.Itoa(int(st.Size())))
-	c.Header("Content-Disposition", "attachment; filename="+st.Name())
+	c.Header("Content-Disposition", "attachment; filename="+strconv.Quote(st.Name()))
 	c.Header("Content-Type", "application/octet-stream")
 
 	bufio.NewReader(f).WriteTo(c.Writer)
@@ -96,7 +96,7 @@ func getDownloadFile(c *gin.Context) {
 	}
 
 	c.Header("Content-Length", strconv.Itoa(int(st.Size())))
-	c.Header("Content-Disposition", "attachment; filename="+st.Name())
+	c.Header("Content-Disposition", "attachment; filename="+strconv.Quote(st.Name()))
 	c.Header("Content-Type", "application/octet-stream")
 
 	bufio.NewReader(f).WriteTo(c.Writer)

--- a/router/router_server_files.go
+++ b/router/router_server_files.go
@@ -39,7 +39,7 @@ func getServerFileContents(c *gin.Context) {
 	// If a download parameter is included in the URL go ahead and attach the necessary headers
 	// so that the file can be downloaded.
 	if c.Query("download") != "" {
-		c.Header("Content-Disposition", "attachment; filename="+st.Name())
+		c.Header("Content-Disposition", "attachment; filename="+strconv.Quote(st.Name()))
 		c.Header("Content-Type", "application/octet-stream")
 	}
 	defer c.Writer.Flush()

--- a/router/router_transfer.go
+++ b/router/router_transfer.go
@@ -102,7 +102,7 @@ func getServerArchive(c *gin.Context) {
 	c.Header("X-Checksum", checksum)
 	c.Header("X-Mime-Type", st.Mimetype)
 	c.Header("Content-Length", strconv.Itoa(int(st.Size())))
-	c.Header("Content-Disposition", "attachment; filename="+s.Archiver.Name())
+	c.Header("Content-Disposition", "attachment; filename="+strconv.Quote(s.Archiver.Name()))
 	c.Header("Content-Type", "application/octet-stream")
 
 	bufio.NewReader(file).WriteTo(c.Writer)


### PR DESCRIPTION
The [standard ](https://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1)requires that the filenames in the Content-Disposition header are quoted.
Some user-agents that strictly follow the standard will cut the filename off at the first space. Example of before and after this patch included in the image.

This patch wraps the filename with quotes and escapes any other quotes in the filename.

![image](https://user-images.githubusercontent.com/388231/108618289-eb160e00-7457-11eb-91e2-8f577a8c4c5a.png)
