### PR TITLE
Fixed /api/servers

### DIFF
--- a/router/router_system.go
+++ b/router/router_system.go
@@ -28,7 +28,15 @@ func getSystemInformation(c *gin.Context) {
 // Returns all of the servers that are registered and configured correctly on
 // this wings instance.
 func getAllServers(c *gin.Context) {
-	c.JSON(http.StatusOK, middleware.ExtractManager(c).All())
+	servers := middleware.ExtractManager(c).All()
+	var procData []serverProcData
+	for _, v := range servers {
+		procData = append(procData, serverProcData{
+			ResourceUsage: v.Proc(),
+			Suspended: v.IsSuspended(),
+		})
+	}
+	c.JSON(http.StatusOK, procData)
 }
 
 // Creates a new server on the wings daemon and begins the installation process

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -8,7 +8,7 @@ import (
 
 type EggConfiguration struct {
 	// The internal UUID of the Egg on the Panel.
-	ID string
+	ID string `json:"id"`
 
 	// Maintains a list of files that are blacklisted for opening/editing/downloading
 	// or basically any type of access on the server by any user. This is NOT the same
@@ -43,7 +43,6 @@ type Configuration struct {
 	Build                 environment.Limits      `json:"build"`
 	CrashDetectionEnabled bool                    `default:"true" json:"enabled" yaml:"enabled"`
 	Mounts                []Mount                 `json:"mounts"`
-	Resources             ResourceUsage           `json:"resources"`
 	Egg                   EggConfiguration        `json:"egg,omitempty"`
 
 	Container struct {


### PR DESCRIPTION
The `/api/servers` endpoint seemed to only return an empty json. This basically fixes that.