### PR TITLE
Fix reading User.Gid from WINGS_GID over WINGS_UID

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -395,7 +395,7 @@ func EnsurePterodactylUser() error {
 	if sysName == "busybox" {
 		_config.System.Username = system.FirstNotEmpty(os.Getenv("WINGS_USERNAME"), "pterodactyl")
 		_config.System.User.Uid = system.MustInt(system.FirstNotEmpty(os.Getenv("WINGS_UID"), "988"))
-		_config.System.User.Gid = system.MustInt(system.FirstNotEmpty(os.Getenv("WINGS_UID"), "988"))
+		_config.System.User.Gid = system.MustInt(system.FirstNotEmpty(os.Getenv("WINGS_GID"), "988"))
 		return nil
 	}
 


### PR DESCRIPTION
The docker/busybox solution reads from WINGS_UID for both the UID and GID. Simple patch to fix that so it reads them from their respective variables.