### PR TITLE
Fix disappearing envs

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -129,7 +129,7 @@ eloop:
 	for k := range s.Config().EnvVars {
 		// Don't allow any environment variables that we have already set above.
 		for _, e := range out {
-			if strings.HasPrefix(e, (strings.ToUpper(k) + "=")) {
+			if strings.HasPrefix(e, strings.ToUpper(k) + "=") {
 				continue eloop
 			}
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -129,7 +129,7 @@ eloop:
 	for k := range s.Config().EnvVars {
 		// Don't allow any environment variables that we have already set above.
 		for _, e := range out {
-			if strings.HasPrefix(e, strings.ToUpper(k)) {
+			if strings.HasPrefix(e, (strings.ToUpper(k) + "=")) {
 				continue eloop
 			}
 		}


### PR DESCRIPTION
If you have two env variables (for example ONE_VARIABLE and ONE_VARIABLE_NAME) ONE_VARIABLE_NAME has prefix ONE_VARIABLE and will be skipped.