### PR TITLE
updated logrotate creation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -547,7 +547,7 @@ func EnableLogRotation() error {
     maxage 7
     missingok
     notifempty
-    create 0640 {{.User.Uid}} {{.User.Gid}}
+    create 0640 root root
     postrotate
         killall -SIGHUP wings
     endscript


### PR DESCRIPTION
The problem is that Wings applies a wrong logrotate config. Logrotate cannot find the user '0' and the group '0' and thus never rotates the log. My following pr fixes this issue.

Issue:
https://github.com/pterodactyl/panel/issues/3452