### PR TITLE
Cleanup server sync logic to work in a single consistent format

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/pterodactyl/wings/remote"
 	"github.com/pterodactyl/wings/router/middleware"
-	"github.com/pterodactyl/wings/server"
+	wserver "github.com/pterodactyl/wings/server"
 )
 
 // Configure configures the routing infrastructure for this daemon instance.
-func Configure(m *server.Manager, client remote.Client) *gin.Engine {
+func Configure(m *wserver.Manager, client remote.Client) *gin.Engine {
 	gin.SetMode("release")
 
 	router := gin.New()
@@ -63,7 +63,6 @@ func Configure(m *server.Manager, client remote.Client) *gin.Engine {
 	server.Use(middleware.RequireAuthorization(), middleware.ServerExists())
 	{
 		server.GET("", getServer)
-		server.PATCH("", patchServer)
 		server.DELETE("", deleteServer)
 
 		server.GET("/logs", getServerLogs)
@@ -71,6 +70,7 @@ func Configure(m *server.Manager, client remote.Client) *gin.Engine {
 		server.POST("/commands", postServerCommands)
 		server.POST("/install", postServerInstall)
 		server.POST("/reinstall", postServerReinstall)
+		server.POST("/sync", postServerSync)
 		server.POST("/ws/deny", postServerDenyWSTokens)
 
 		// This archive request causes the archive to start being created

--- a/server/manager.go
+++ b/server/manager.go
@@ -172,8 +172,11 @@ func (m *Manager) InitServer(data remote.ServerConfigurationResponse) (*Server, 
 	if err != nil {
 		return nil, err
 	}
-	if err := s.UpdateDataStructure(data.Settings); err != nil {
-		return nil, err
+
+	// Setup the base server configuration data which will be used for all of the
+	// remaining functionality in this call.
+	if err := s.SyncWithConfiguration(data); err != nil {
+		return nil, errors.WithStackIf(err)
 	}
 
 	s.fs = filesystem.New(filepath.Join(config.Get().System.Data, s.ID()), s.DiskSpace(), s.Config().Egg.FileDenylist)
@@ -198,11 +201,6 @@ func (m *Manager) InitServer(data remote.ServerConfigurationResponse) (*Server, 
 		s.Environment = env
 		s.StartEventListeners()
 		s.Throttler().StartTimer(s.Context())
-	}
-
-	// Forces the configuration to be synced with the panel.
-	if err := s.SyncWithConfiguration(data); err != nil {
-		return nil, err
 	}
 
 	// If the server's data directory exists, force disk usage calculation.

--- a/server/update.go
+++ b/server/update.go
@@ -1,148 +1,40 @@
 package server
 
 import (
-	"encoding/json"
-
-	"emperror.dev/errors"
-	"github.com/buger/jsonparser"
-	"github.com/imdario/mergo"
+	"github.com/pterodactyl/wings/environment/docker"
 
 	"github.com/pterodactyl/wings/environment"
 )
 
-// UpdateDataStructure merges data passed through in JSON form into the existing
-// server object. Any changes to the build settings will apply immediately in
-// the environment if the environment supports it.
+// SyncWithEnvironment updates the environment for the server to match any of
+// the changed data. This pushes new settings and environment variables to the
+// environment. In addition, the in-situ update method is called on the
+// environment which will allow environments that make use of it (such as Docker)
+// to immediately apply some settings without having to wait on a server to
+// restart.
 //
-// The server will be marked as requiring a rebuild on the next boot sequence,
-// it is up to the specific environment to determine what needs to happen when
-// that is the case.
-func (s *Server) UpdateDataStructure(data []byte) error {
-	src := new(Configuration)
-	if err := json.Unmarshal(data, src); err != nil {
-		return errors.Wrap(err, "server/update: could not unmarshal source data into Configuration struct")
-	}
-
-	// Don't allow obviously corrupted data to pass through into this function. If the UUID
-	// doesn't match something has gone wrong and the API is attempting to meld this server
-	// instance into a totally different one, which would be bad.
-	if src.Uuid != "" && s.ID() != "" && src.Uuid != s.ID() {
-		return errors.New("server/update: attempting to merge a data stack with an invalid UUID")
-	}
-
-	// Grab a copy of the configuration to work on.
-	c := *s.Config()
-
-	// Lock our copy of the configuration since the deferred unlock will end up acting upon this
-	// new memory address rather than the old one. If we don't lock this, the deferred unlock will
-	// cause a panic when it goes to run. However, since we only update s.cfg at the end, if there
-	// is an error before that point we'll still properly unlock the original configuration for the
-	// server.
-	c.mu.Lock()
-
-	// Lock the server configuration while we're doing this merge to avoid anything
-	// trying to overwrite it or make modifications while we're sorting out what we
-	// need to do.
-	s.cfg.mu.Lock()
-	defer s.cfg.mu.Unlock()
-
-	// Merge the new data object that we have received with the existing server data object
-	// and then save it to the disk so it is persistent.
-	if err := mergo.Merge(&c, src, mergo.WithOverride); err != nil {
-		return errors.WithStack(err)
-	}
-
-	// Don't explode if we're setting CPU limits to 0. Mergo sees that as an empty value
-	// so it won't override the value we've passed through in the API call. However, we can
-	// safely assume that we're passing through valid data structures here. I foresee this
-	// backfiring at some point, but until then...
-	c.Build = src.Build
-
-	// Yee haw.
-	c.Egg = src.Egg
-
-	// Mergo can't quite handle this boolean value correctly, so for now we'll just
-	// handle this edge case manually since none of the other data passed through in this
-	// request is going to be boolean. Allegedly.
-	if v, err := jsonparser.GetBoolean(data, "container", "oom_disabled"); err != nil {
-		if err != jsonparser.KeyPathNotFoundError {
-			return errors.WithStack(err)
-		}
-	} else {
-		c.Build.OOMDisabled = v
-	}
-
-	// Mergo also cannot handle this boolean value.
-	if v, err := jsonparser.GetBoolean(data, "suspended"); err != nil {
-		if err != jsonparser.KeyPathNotFoundError {
-			return errors.WithStack(err)
-		}
-	} else {
-		c.Suspended = v
-	}
-
-	if v, err := jsonparser.GetBoolean(data, "skip_egg_scripts"); err != nil {
-		if err != jsonparser.KeyPathNotFoundError {
-			return errors.WithStack(err)
-		}
-	} else {
-		c.SkipEggScripts = v
-	}
-
-	if v, err := jsonparser.GetBoolean(data, "start_on_completion"); err != nil {
-		if err != jsonparser.KeyPathNotFoundError {
-			return errors.WithStack(err)
-		}
-	} else {
-		c.StartOnCompletion = v
-	}
-
-	if v, err := jsonparser.GetBoolean(data, "crash_detection_enabled"); err != nil {
-		if err != jsonparser.KeyPathNotFoundError {
-			return errors.WithStack(err)
-		}
-		// Enable crash detection by default.
-		c.CrashDetectionEnabled = true
-	} else {
-		c.CrashDetectionEnabled = v
-	}
-
-	// Environment and Mappings should be treated as a full update at all times, never a
-	// true patch, otherwise we can't know what we're passing along.
-	if src.EnvVars != nil && len(src.EnvVars) > 0 {
-		c.EnvVars = src.EnvVars
-	}
-
-	if src.Allocations.Mappings != nil && len(src.Allocations.Mappings) > 0 {
-		c.Allocations.Mappings = src.Allocations.Mappings
-	}
-
-	if src.Mounts != nil && len(src.Mounts) > 0 {
-		c.Mounts = src.Mounts
-	}
-
-	// Update the configuration once we have a lock on the configuration object.
-	s.cfg = c
-
-	return nil
-}
-
-// Updates the environment for the server to match any of the changed data. This pushes new settings and
-// environment variables to the environment. In addition, the in-situ update method is called on the
-// environment which will allow environments that make use of it (such as Docker) to immediately apply
-// some settings without having to wait on a server to restart.
-//
-// This functionality allows a server's resources limits to be modified on the fly and have them apply
-// right away allowing for dynamic resource allocation and responses to abusive server processes.
+// This functionality allows a server's resources limits to be modified on the
+// fly and have them apply right away allowing for dynamic resource allocation
+// and responses to abusive server processes.
 func (s *Server) SyncWithEnvironment() {
 	s.Log().Debug("syncing server settings with environment")
+
+	cfg := s.Config()
 
 	// Update the environment settings using the new information from this server.
 	s.Environment.Config().SetSettings(environment.Settings{
 		Mounts:      s.Mounts(),
-		Allocations: s.Config().Allocations,
-		Limits:      s.Config().Build,
+		Allocations: cfg.Allocations,
+		Limits:      cfg.Build,
 	})
+
+	// For Docker specific environments we also want to update the configured image
+	// and stop configuration.
+	if e, ok := s.Environment.(*docker.Environment); ok {
+		s.Log().Debug("syncing stop configuration with configured docker environment")
+		e.SetImage(cfg.Container.Image)
+		e.SetStopConfiguration(s.ProcessConfiguration().Stop)
+	}
 
 	// If build limits are changed, environment variables also change. Plus, any modifications to
 	// the startup command also need to be properly propagated to this environment.


### PR DESCRIPTION
Previously we had a mess of a function trying to update server details from a patch request. This change just centralizes everything to a single Sync() call when a server needs to update itself.

We can also eventually update the panel (in V2) to not hit the patch endpoint, rather it can just be a generic endpoint that is hit after a server is updated on the Panel that tells Wings to re-sync the data to get the environment changes on the fly.

The changes I made to the patch function currently act like that, with a slightly fragile 2 second wait to let the panel persist the changes since I don't want this to be a breaking change on that end.