### PR TITLE
Use GID from config for container

### DIFF
--- a/environment/docker/container.go
+++ b/environment/docker/container.go
@@ -175,7 +175,7 @@ func (e *Environment) Create() error {
 	conf := &container.Config{
 		Hostname:     e.Id,
 		Domainname:   config.Get().Docker.Domainname,
-		User:         strconv.Itoa(config.Get().System.User.Uid),
+		User:         strconv.Itoa(config.Get().System.User.Uid) + ":" + strconv.Itoa(config.Get().System.User.Gid),
 		AttachStdin:  true,
 		AttachStdout: true,
 		AttachStderr: true,


### PR DESCRIPTION
The wings config file has an option for specifying the GID, but it doesn't seem to be used in the container. This PR aims to fix that by passing the configured gid to the container config. This seems to do the job, as shown in the highly advanced tests below /s

Before:
![image](https://user-images.githubusercontent.com/44026893/135727854-dd515ad2-cf68-47e2-b7e0-1a0576e26de2.png)

After:
![image](https://user-images.githubusercontent.com/44026893/135727859-d9b641c7-4628-4f61-b0e9-303d17f8decb.png)
