### PR TITLE
Fix Upper Case SSL Path

### DIFF
--- a/router/router_system.go
+++ b/router/router_system.go
@@ -109,8 +109,8 @@ func postUpdateConfiguration(c *gin.Context) {
 	//
 	// If you pass through manual locations in the API call this logic will be skipped.
 	if strings.HasPrefix(cfg.Api.Ssl.KeyFile, "/etc/letsencrypt/live/") {
-		cfg.Api.Ssl.KeyFile = strings.ToLower(config.Get().Api.Ssl.KeyFile)
-		cfg.Api.Ssl.CertificateFile = strings.ToLower(config.Get().Api.Ssl.CertificateFile)
+		cfg.Api.Ssl.KeyFile = config.Get().Api.Ssl.KeyFile
+		cfg.Api.Ssl.CertificateFile = config.Get().Api.Ssl.CertificateFile
 	}
 	// Try to write this new configuration to the disk before updating our global
 	// state with it.


### PR DESCRIPTION
This fixes https://github.com/pterodactyl/panel/issues/3816 by removing a toLowerCase call on the SSL path in the config.