### PR TITLE
Actually enforce upload file size limit

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -90,8 +90,8 @@ type ApiConfiguration struct {
 	// servers.
 	DisableRemoteDownload bool `json:"disable_remote_download" yaml:"disable_remote_download"`
 
-	// The maximum size for files uploaded through the Panel in bytes.
-	UploadLimit int `default:"100" json:"upload_limit" yaml:"upload_limit"`
+	// The maximum size for files uploaded through the Panel in MB.
+	UploadLimit int64 `default:"100" json:"upload_limit" yaml:"upload_limit"`
 }
 
 // RemoteQueryConfiguration defines the configuration settings for remote requests


### PR DESCRIPTION
Wings has a upload limit config option, but it didn't actually do anything.
This PR re-adds that check per-file, similar to how it was handled [in the old JS daemon](https://github.com/pterodactyl/daemon/blob/ca642f399528495bfde22760898d6aad297d3e9e/src/http/upload.js#L62). 