### PR TITLE
Add an option to change the compression level of backups

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -210,6 +210,15 @@ type Backups struct {
 	//
 	// Defaults to 0 (unlimited)
 	WriteLimit int `default:"0" yaml:"write_limit"`
+
+	// CompressionLevel determines how much backups created by wings should be compressed.
+	//
+	// "none" -> no compression will be applied
+	// "best_speed" -> uses gzip level 1 for fast speed
+	// "best_compression" -> uses gzip level 9 for minimal disk space useage
+	//
+	// Defaults to "best_speed" (level 1)
+	CompressionLevel string `default:"best_speed" yaml:"compression_level"`
 }
 
 type Transfers struct {

--- a/server/filesystem/archive.go
+++ b/server/filesystem/archive.go
@@ -62,8 +62,21 @@ func (a *Archive) Create(dst string) error {
 		writer = f
 	}
 
+	// The default compression level is BestSpeed
+	var cl = pgzip.BestSpeed
+
+	// Choose which compression level to use based on the compression_level configuration option
+	switch config.Get().System.Backups.CompressionLevel {
+	case "none":
+		cl = pgzip.NoCompression
+	case "best_speed":
+		cl = pgzip.BestSpeed
+	case "best_compression":
+		cl = pgzip.BestCompression
+	}
+
 	// Create a new gzip writer around the file.
-	gw, _ := pgzip.NewWriterLevel(writer, pgzip.BestSpeed)
+	gw, _ := pgzip.NewWriterLevel(writer, cl)
 	_ = gw.SetConcurrency(1<<20, 1)
 	defer gw.Close()
 


### PR DESCRIPTION
Hi, this adds an option to the config file to change the compression level of backups.
I made this so I can make use of ZFS deduplication which only works on uncompressed files. 