### PR TITLE
Make the Docker network MTU configurable

### DIFF
--- a/config/config_docker.go
+++ b/config/config_docker.go
@@ -36,6 +36,7 @@ type DockerNetworkConfiguration struct {
 	Mode       string                  `default:"pterodactyl_nw" yaml:"network_mode"`
 	IsInternal bool                    `default:"false" yaml:"is_internal"`
 	EnableICC  bool                    `default:"true" yaml:"enable_icc"`
+	NetworkMTU int64                   `default:"1500" yaml:"network_mtu"`
 	Interfaces dockerNetworkInterfaces `yaml:"interfaces"`
 }
 

--- a/environment/docker.go
+++ b/environment/docker.go
@@ -92,7 +92,7 @@ func createDockerNetwork(ctx context.Context, cli *client.Client) error {
 			"com.docker.network.bridge.enable_ip_masquerade": "true",
 			"com.docker.network.bridge.host_binding_ipv4":    "0.0.0.0",
 			"com.docker.network.bridge.name":                 "pterodactyl0",
-			"com.docker.network.driver.mtu":                  "1500",
+			"com.docker.network.driver.mtu":                  strconv.FormatInt(nw.NetworkMTU, 10),
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
I have to modify the pterodactyl_nw network's MTU size to 1280 because my TLS handshakes just do not work from within the container because of services trying to connect over a network interface that has an MTU lower than 1500.

This PR adds the network_mtu config option to configure the MTU. The Docker network will have to be manually removed with `docker network rm pterodactyl_nw` & Wings needs to start afterwards in order to apply changes but I think that's fine.