### PR TITLE
Add support for trusted proxies

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -91,6 +91,9 @@ type ApiConfiguration struct {
 
 	// The maximum size for files uploaded through the Panel in MB.
 	UploadLimit int64 `default:"100" json:"upload_limit" yaml:"upload_limit"`
+
+	// A list of IP address of proxies that may send a X-Forwarded-For header to set the true clients IP
+	TrustedProxies []string `json:"trusted_proxies" yaml:"trusted_proxies"`
 }
 
 // RemoteQueryConfiguration defines the configuration settings for remote requests

--- a/router/router.go
+++ b/router/router.go
@@ -4,6 +4,7 @@ import (
 	"github.com/apex/log"
 	"github.com/gin-gonic/gin"
 
+	"github.com/pterodactyl/wings/config"
 	"github.com/pterodactyl/wings/remote"
 	"github.com/pterodactyl/wings/router/middleware"
 	wserver "github.com/pterodactyl/wings/server"
@@ -15,6 +16,7 @@ func Configure(m *wserver.Manager, client remote.Client) *gin.Engine {
 
 	router := gin.New()
 	router.Use(gin.Recovery())
+	router.SetTrustedProxies(config.Get().Api.TrustedProxies)
 	router.Use(middleware.AttachRequestID(), middleware.CaptureErrors(), middleware.SetAccessControlHeaders())
 	router.Use(middleware.AttachServerManager(m), middleware.AttachApiClient(client))
 	// @todo log this into a different file so you can setup IP blocking for abusive requests and such.

--- a/router/router_server_files.go
+++ b/router/router_server_files.go
@@ -602,7 +602,7 @@ func postServerUploadFiles(c *gin.Context) {
 			NewServerError(err, s).Abort(c)
 			return
 		} else {
-			s.SaveActivity(s.NewRequestActivity(token.UserUuid, c.Request.RemoteAddr), server.ActivityFileUploaded, models.ActivityMeta{
+			s.SaveActivity(s.NewRequestActivity(token.UserUuid, c.ClientIP()), server.ActivityFileUploaded, models.ActivityMeta{
 				"file":      header.Filename,
 				"directory": filepath.Clean(directory),
 			})

--- a/router/router_server_ws.go
+++ b/router/router_server_ws.go
@@ -32,7 +32,7 @@ func getServerWebsocket(c *gin.Context) {
 	ctx, cancel := context.WithCancel(c.Request.Context())
 	defer cancel()
 
-	handler, err := websocket.GetHandler(s, c.Writer, c.Request)
+	handler, err := websocket.GetHandler(s, c.Writer, c.Request, c)
 	if err != nil {
 		NewServerError(err, s).Abort(c)
 		return

--- a/router/websocket/websocket.go
+++ b/router/websocket/websocket.go
@@ -12,6 +12,7 @@ import (
 	"emperror.dev/errors"
 	"github.com/apex/log"
 	"github.com/gbrlsnchs/jwt/v3"
+	"github.com/gin-gonic/gin"
 	"github.com/goccy/go-json"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
@@ -79,7 +80,7 @@ func NewTokenPayload(token []byte) (*tokens.WebsocketPayload, error) {
 }
 
 // GetHandler returns a new websocket handler using the context provided.
-func GetHandler(s *server.Server, w http.ResponseWriter, r *http.Request) (*Handler, error) {
+func GetHandler(s *server.Server, w http.ResponseWriter, r *http.Request, c *gin.Context) (*Handler, error) {
 	upgrader := websocket.Upgrader{
 		// Ensure that the websocket request is originating from the Panel itself,
 		// and not some other location.
@@ -111,7 +112,7 @@ func GetHandler(s *server.Server, w http.ResponseWriter, r *http.Request) (*Hand
 		Connection: conn,
 		jwt:        nil,
 		server:     s,
-		ra:         s.NewRequestActivity("", r.RemoteAddr),
+		ra:         s.NewRequestActivity("", c.ClientIP()),
 		uuid:       u,
 	}, nil
 }


### PR DESCRIPTION
Allows user to set trusted_proxies in the wings config to support reverse proxies sending the clients true IP address for activity logs.

Fixes https://github.com/pterodactyl/panel/issues/4324