### PR TITLE
feat: add user-provided container labels

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,8 +16,8 @@ import (
 	"time"
 
 	"emperror.dev/errors"
+	"github.com/acobaugh/osrelease"
 	"github.com/apex/log"
-	"github.com/cobaugh/osrelease"
 	"github.com/creasty/defaults"
 	"github.com/gbrlsnchs/jwt/v3"
 	"gopkg.in/yaml.v2"

--- a/environment/config.go
+++ b/environment/config.go
@@ -8,6 +8,7 @@ type Settings struct {
 	Mounts      []Mount
 	Allocations Allocations
 	Limits      Limits
+	Labels      map[string]string
 }
 
 // Defines the actual configuration struct for the environment with all of the settings
@@ -16,16 +17,14 @@ type Configuration struct {
 	mu sync.RWMutex
 
 	environmentVariables []string
-	labels               map[string]string
 	settings             Settings
 }
 
 // Returns a new environment configuration with the given settings and environment variables
 // defined within it.
-func NewConfiguration(s Settings, envVars []string, labels map[string]string) *Configuration {
+func NewConfiguration(s Settings, envVars []string) *Configuration {
 	return &Configuration{
 		environmentVariables: envVars,
-		labels:               labels,
 		settings:             s,
 	}
 }
@@ -70,18 +69,18 @@ func (c *Configuration) Mounts() []Mount {
 	return c.settings.Mounts
 }
 
+// Labels returns the container labels associated with this instance.
+func (c *Configuration) Labels() map[string]string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.settings.Labels
+}
+
 // Returns the environment variables associated with this instance.
 func (c *Configuration) EnvironmentVariables() []string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
 	return c.environmentVariables
-}
-
-// Labels returns the container labels associated with this instance.
-func (c *Configuration) Labels() map[string]string {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	return c.labels
 }

--- a/environment/config.go
+++ b/environment/config.go
@@ -16,14 +16,16 @@ type Configuration struct {
 	mu sync.RWMutex
 
 	environmentVariables []string
+	labels               map[string]string
 	settings             Settings
 }
 
 // Returns a new environment configuration with the given settings and environment variables
 // defined within it.
-func NewConfiguration(s Settings, envVars []string) *Configuration {
+func NewConfiguration(s Settings, envVars []string, labels map[string]string) *Configuration {
 	return &Configuration{
 		environmentVariables: envVars,
+		labels:               labels,
 		settings:             s,
 	}
 }
@@ -74,4 +76,12 @@ func (c *Configuration) EnvironmentVariables() []string {
 	defer c.mu.RUnlock()
 
 	return c.environmentVariables
+}
+
+// Labels returns the container labels associated with this instance.
+func (c *Configuration) Labels() map[string]string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.labels
 }

--- a/environment/docker/container.go
+++ b/environment/docker/container.go
@@ -174,6 +174,16 @@ func (e *Environment) Create() error {
 		}
 	}
 
+	// Merge user-provided labels with system labels
+	confLabels := e.Configuration.Labels()
+	labels := make(map[string]string, 2+len(confLabels))
+
+	for key := range confLabels {
+		labels[key] = confLabels[key]
+	}
+	labels["Service"] = "Pterodactyl"
+	labels["ContainerType"] = "server_process"
+
 	conf := &container.Config{
 		Hostname:     e.Id,
 		Domainname:   config.Get().Docker.Domainname,
@@ -186,10 +196,7 @@ func (e *Environment) Create() error {
 		ExposedPorts: a.Exposed(),
 		Image:        strings.TrimPrefix(e.meta.Image, "~"),
 		Env:          e.Configuration.EnvironmentVariables(),
-		Labels: map[string]string{
-			"Service":       "Pterodactyl",
-			"ContainerType": "server_process",
-		},
+		Labels:       labels,
 	}
 
 	networkMode := container.NetworkMode(config.Get().Docker.Network.Mode)

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/Jeffail/gabs/v2 v2.6.1
 	github.com/NYTimes/logrotate v1.0.0
+	github.com/acobaugh/osrelease v0.1.0
 	github.com/apex/log v1.9.0
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/beevik/etree v1.1.0
 	github.com/buger/jsonparser v1.1.1
 	github.com/cenkalti/backoff/v4 v4.1.3
-	github.com/cobaugh/osrelease v0.0.0-20181218015638-a93a0a55a249
 	github.com/creasty/defaults v1.6.0
 	github.com/docker/docker v20.10.18+incompatible
 	github.com/docker/go-connections v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
+github.com/acobaugh/osrelease v0.1.0 h1:Yb59HQDGGNhCj4suHaFQQfBps5wyoKLSSX/J/+UifRE=
+github.com/acobaugh/osrelease v0.1.0/go.mod h1:4bFEs0MtgHNHBrmHCt67gNisnabCRAlzdVasCEGHTWY=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -151,8 +153,6 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/cobaugh/osrelease v0.0.0-20181218015638-a93a0a55a249 h1:R0IDH8daQ3lODvu8YtxnIqqth5qMGCJyADoUQvmLx4o=
-github.com/cobaugh/osrelease v0.0.0-20181218015638-a93a0a55a249/go.mod h1:EHKW9yNEYSBpTKzuu7Y9oOrft/UlzH57rMIB03oev6M=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=
 github.com/containerd/aufs v0.0.0-20201003224125-76a6863f2989/go.mod h1:AkGGQs9NM2vtYHaUen+NljV0/baGCAPELGm2q9ZXpWU=

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -46,6 +46,9 @@ type Configuration struct {
 	// server process.
 	EnvVars environment.Variables `json:"environment"`
 
+	// Labels is a map of container labels that should be applied to the running server process.
+	Labels map[string]string `json:"labels"`
+
 	Allocations           environment.Allocations `json:"allocations"`
 	Build                 environment.Limits      `json:"build"`
 	CrashDetectionEnabled bool                    `json:"crash_detection_enabled"`

--- a/server/manager.go
+++ b/server/manager.go
@@ -207,7 +207,7 @@ func (m *Manager) InitServer(data remote.ServerConfigurationResponse) (*Server, 
 		Limits:      s.cfg.Build,
 	}
 
-	envCfg := environment.NewConfiguration(settings, s.GetEnvironmentVariables())
+	envCfg := environment.NewConfiguration(settings, s.GetEnvironmentVariables(), s.Config().Labels)
 	meta := docker.Metadata{
 		Image: s.Config().Container.Image,
 	}

--- a/server/manager.go
+++ b/server/manager.go
@@ -205,9 +205,10 @@ func (m *Manager) InitServer(data remote.ServerConfigurationResponse) (*Server, 
 		Mounts:      s.Mounts(),
 		Allocations: s.cfg.Allocations,
 		Limits:      s.cfg.Build,
+		Labels:      s.cfg.Labels,
 	}
 
-	envCfg := environment.NewConfiguration(settings, s.GetEnvironmentVariables(), s.Config().Labels)
+	envCfg := environment.NewConfiguration(settings, s.GetEnvironmentVariables())
 	meta := docker.Metadata{
 		Image: s.Config().Container.Image,
 	}


### PR DESCRIPTION
This PR adds support for user-provided container labels. Resolves https://github.com/pterodactyl/panel/issues/3100.

## Why?

This makes it easier for service discovery mechanisms relying on container labels, such as Prometheus and Traefik.

## Example Use-cases

- Set a label on Minecraft servers for Prometheus to discover and scrape automatically
- Set labels on Minecraft servers with DynMap (or similar) to automatically set up routers and endpoints on Traefik reverse proxy
