### PR TITLE
Docs for EL/CentOS/Fedora CA certs path

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -22,7 +22,10 @@ services:
       - "/var/lib/pterodactyl/:/var/lib/pterodactyl/"
       - "/var/log/pterodactyl/:/var/log/pterodactyl/"
       - "/tmp/pterodactyl/:/tmp/pterodactyl/"
+      # Comment out the following line if host is not Ubuntu- or Debian-based distribution
       - "/etc/ssl/certs:/etc/ssl/certs:ro"
+      # Uncomment the following if host is RHEL/CentOS/Fedora/other EL
+      # - "/etc/ssl/certs/ca-certificates.crt:/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt:ro"
       # you may need /srv/daemon-data if you are upgrading from an old daemon
       #- "/srv/daemon-data/:/srv/daemon-data/"
       # Required for ssl if you use let's encrypt. uncomment to use.


### PR DESCRIPTION
Works around https://github.com/pterodactyl/panel/issues/3096 (which couldn't be reproduced at the time, presumably due to no one happening to run EL) by adding documentation of alternative location for CA certs. The location of CA certificates varies by distribution. Debian/Ubuntu and derivatives use /etc/ssl/certs as the location for CA certs, but that path is hardcoded into the official Wings image, so adding an alt path to mount is the next best thing.

Without having the correct cert location, you can fall back to the one inside the container of course, but it's preferable to use the host's. I don't know about other distros, but I found what is necessary for it to work on EL. By default, on EL, an x509 error occurs and Wings is unreachable.