### PR TITLE
Remove Topic splitting

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -1,8 +1,6 @@
 package events
 
 import (
-	"strings"
-
 	"emperror.dev/errors"
 	"github.com/goccy/go-json"
 
@@ -34,18 +32,6 @@ func NewBus() *Bus {
 
 // Publish publishes a message to the Bus.
 func (b *Bus) Publish(topic string, data interface{}) {
-	// Some of our actions for the socket support passing a more specific namespace,
-	// such as "backup completed:1234" to indicate which specific backup was completed.
-	//
-	// In these cases, we still need to send the event using the standard listener
-	// name of "backup completed".
-	if strings.Contains(topic, ":") {
-		parts := strings.SplitN(topic, ":", 2)
-		if len(parts) == 2 {
-			topic = parts[0]
-		}
-	}
-
 	enc, err := json.Marshal(Event{Topic: topic, Data: data})
 	if err != nil {
 		panic(errors.WithStack(err))


### PR DESCRIPTION
```
	// Some of our actions for the socket support passing a more specific namespace,
	// such as "backup completed:1234" to indicate which specific backup was completed.
	//
	// In these cases, we still need to send the event using the standard listener
	// name of "backup completed".
```
^ This is wrong. `BackupRow.tsx` specifically listens on `${SocketEvent.BACKUP_COMPLETED}:${backup.uuid}`.
This resolves an issue I discovered, where backups would remain in a "loading"-state on the frontend, until the user refreshes the page, or the `revalidateOnFocus`-event was triggered.

Alternatively, the frontend could be modified to listen for the correct SocketEvent name.