### PR TITLE
activity: fix ip validity check

### DIFF
--- a/internal/cron/activity_cron.go
+++ b/internal/cron/activity_cron.go
@@ -49,7 +49,7 @@ func (ac *activityCron) Run(ctx context.Context) error {
 	for _, v := range activity {
 		// Delete any activity that has an invalid IP address. This is a fix for
 		// a bug that truncated the last octet of an IPv6 address in the database.
-		if err := net.ParseIP(v.IP); err != nil {
+		if ip := net.ParseIP(v.IP); ip == nil {
 			ids = append(ids, v.ID)
 			continue
 		}


### PR DESCRIPTION
`net.ParseIP()` returns an IP object when the IP passed in is valid and `nil` when the IP is invalid.
This fixes the check as before it seems that all activity log entries that have a valid IP are dropped instead of the invalid IP entries.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

***
Related commit: https://github.com/pterodactyl/wings/commit/18de96d7b864cd9ba29408029178f344fb5fefd6

Please let me know if you have any questions.