### PR TITLE
config: add option to disable panel config updates

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -319,6 +319,9 @@ type Configuration struct {
 	// is only required by users running Wings without SSL certificates and using internal IP
 	// addresses in order to connect. Most users should NOT enable this setting.
 	AllowCORSPrivateNetwork bool `json:"allow_cors_private_network" yaml:"allow_cors_private_network"`
+
+	// IgnorePanelConfigUpdates causes confiuration updates that are sent by the panel to be ignored.
+	IgnorePanelConfigUpdates bool `json:"ignore_panel_config_updates" yaml:"ignore_panel_config_updates"`
 }
 
 // NewAtPath creates a new struct and set the path where it should be stored.

--- a/router/router_system.go
+++ b/router/router_system.go
@@ -113,9 +113,21 @@ func postCreateServer(c *gin.Context) {
 	c.Status(http.StatusAccepted)
 }
 
+type postUpdateConfigurationResponse struct {
+	Applied bool `json:"applied"`
+}
+
 // Updates the running configuration for this Wings instance.
 func postUpdateConfiguration(c *gin.Context) {
 	cfg := config.Get()
+
+	if cfg.IgnorePanelConfigUpdates {
+		c.JSON(http.StatusOK, postUpdateConfigurationResponse{
+			Applied: false,
+		})
+		return
+	}
+
 	if err := c.BindJSON(&cfg); err != nil {
 		return
 	}
@@ -139,5 +151,7 @@ func postUpdateConfiguration(c *gin.Context) {
 	// Since we wrote it to the disk successfully now update the global configuration
 	// state to use this new configuration struct.
 	config.Set(cfg)
-	c.Status(http.StatusNoContent)
+	c.JSON(http.StatusOK, postUpdateConfigurationResponse{
+		Applied: true,
+	})
 }


### PR DESCRIPTION
Adds a new config option `ignore_panel_config_updates: {true,false}` that allows to ignore configuration updates sent by the panel.

pterodactyl/panel#4707