### PR TITLE
resolve issues with missing user in containers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -535,7 +535,7 @@ func ConfigureDirectories() error {
 		return err
 	} else {
 		// the WriteFile method returns an error if unsuccessful
-		err := os.WriteFile(passwd.Name(), []byte(fmt.Sprintf("container:x:%d:%d::/home/container:/usr/sbin/nologin", _config.System.User.Uid, _config.System.User.Gid)), 0755)
+		err := os.WriteFile(passwd.Name(), []byte(fmt.Sprintf("container:x:%d:%d::/home/container:/usr/sbin/nologin", _config.System.User.Uid, _config.System.User.Gid)), 0644)
 		// handle this error
 		if err != nil {
 			// print it out

--- a/config/config.go
+++ b/config/config.go
@@ -171,7 +171,8 @@ type SystemConfiguration struct {
 
 		// Passwd controls weather a passwd file is mounted in the container
 		// at /etc/passwd to resolve missing user issues
-		Passwd bool `json:"mount_passwd" yaml:"mount_passwd" default:"true"`
+		Passwd     bool   `json:"mount_passwd" yaml:"mount_passwd" default:"true"`
+		PasswdFile string `json:"passwd_file" yaml:"passwd_file" default:"/etc/pterodactyl/passwd"`
 	} `yaml:"user"`
 
 	// The amount of time in seconds that can elapse before a server's disk space calculation is
@@ -530,8 +531,8 @@ func ConfigureDirectories() error {
 		return err
 	}
 
-	log.WithField("filepath", "/etc/pterodactyl/passwd").Debug("ensuring passwd file exists")
-	if passwd, err := os.Create("/etc/pterodactyl/passwd"); err != nil {
+	log.WithField("filepath", _config.System.User.PasswdFile).Debug("ensuring passwd file exists")
+	if passwd, err := os.Create(_config.System.User.PasswdFile); err != nil {
 		return err
 	} else {
 		// the WriteFile method returns an error if unsuccessful

--- a/config/config.go
+++ b/config/config.go
@@ -169,7 +169,9 @@ type SystemConfiguration struct {
 		Uid int `yaml:"uid"`
 		Gid int `yaml:"gid"`
 
-		Login bool `yaml:"login"`
+		// Passwd controls weather a passwd file is mounted in the container
+		// at /etc/passwd to resolve missing user issues
+		Passwd bool `json:"mount_passwd" yaml:"mount_passwd" default:"true"`
 	} `yaml:"user"`
 
 	// The amount of time in seconds that can elapse before a server's disk space calculation is
@@ -532,13 +534,8 @@ func ConfigureDirectories() error {
 	if passwd, err := os.Create("/etc/pterodactyl/passwd"); err != nil {
 		return err
 	} else {
-		shell := "/usr/sbin/nologin"
-		if _config.System.User.Login {
-			shell = "/bin/sh"
-		}
-
 		// the WriteFile method returns an error if unsuccessful
-		err := os.WriteFile(passwd.Name(), []byte(fmt.Sprintf("container:x:%d:%d::/home/container:%s", _config.System.User.Uid, _config.System.User.Gid, shell)), 0777)
+		err := os.WriteFile(passwd.Name(), []byte(fmt.Sprintf("container:x:%d:%d::/home/container:/usr/sbin/nologin", _config.System.User.Uid, _config.System.User.Gid)), 0755)
 		// handle this error
 		if err != nil {
 			// print it out

--- a/config/config.go
+++ b/config/config.go
@@ -528,7 +528,7 @@ func ConfigureDirectories() error {
 		return err
 	}
 
-	log.WithField("filepath", "/etc/pterodactyl//passwd").Debug("ensuring passwd file exists")
+	log.WithField("filepath", "/etc/pterodactyl/passwd").Debug("ensuring passwd file exists")
 	if passwd, err := os.Create("/etc/pterodactyl/passwd"); err != nil {
 		return err
 	} else {

--- a/config/config.go
+++ b/config/config.go
@@ -168,6 +168,8 @@ type SystemConfiguration struct {
 
 		Uid int `yaml:"uid"`
 		Gid int `yaml:"gid"`
+
+		Login bool `yaml:"login"`
 	} `yaml:"user"`
 
 	// The amount of time in seconds that can elapse before a server's disk space calculation is
@@ -524,6 +526,24 @@ func ConfigureDirectories() error {
 	log.WithField("path", root).Debug("ensuring root data directory exists")
 	if err := os.MkdirAll(root, 0o700); err != nil {
 		return err
+	}
+
+	log.WithField("filepath", "/etc/pterodactyl//passwd").Debug("ensuring passwd file exists")
+	if passwd, err := os.Create("/etc/pterodactyl/passwd"); err != nil {
+		return err
+	} else {
+		shell := "/usr/sbin/nologin"
+		if _config.System.User.Login {
+			shell = "/bin/sh"
+		}
+
+		// the WriteFile method returns an error if unsuccessful
+		err := os.WriteFile(passwd.Name(), []byte(fmt.Sprintf("container:x:%d:%d::/home/container:%s", _config.System.User.Uid, _config.System.User.Gid, shell)), 0777)
+		// handle this error
+		if err != nil {
+			// print it out
+			fmt.Println(err)
+		}
 	}
 
 	// There are a non-trivial number of users out there whose data directories are actually a

--- a/server/mounts.go
+++ b/server/mounts.go
@@ -34,7 +34,7 @@ func (s *Server) Mounts() []environment.Mount {
 		passwdMount := environment.Mount{
 			Default:  true,
 			Target:   "/etc/passwd",
-			Source:   "/etc/pterodactyl/passwd",
+			Source:   config.Get().System.User.PasswdFile,
 			ReadOnly: true,
 		}
 

--- a/server/mounts.go
+++ b/server/mounts.go
@@ -27,12 +27,18 @@ func (s *Server) Mounts() []environment.Mount {
 			Source:   s.Filesystem().Path(),
 			ReadOnly: false,
 		},
-		{
+	}
+
+	// Mount passwd file if set to true
+	if config.Get().System.User.Passwd {
+		passwdMount := environment.Mount{
 			Default:  true,
 			Target:   "/etc/passwd",
 			Source:   "/etc/pterodactyl/passwd",
 			ReadOnly: true,
-		},
+		}
+
+		m = append(m, passwdMount)
 	}
 
 	// Also include any of this server's custom mounts when returning them.

--- a/server/mounts.go
+++ b/server/mounts.go
@@ -27,6 +27,12 @@ func (s *Server) Mounts() []environment.Mount {
 			Source:   s.Filesystem().Path(),
 			ReadOnly: false,
 		},
+		{
+			Default:  true,
+			Target:   "/etc/passwd",
+			Source:   "/etc/pterodactyl/passwd",
+			ReadOnly: true,
+		},
 	}
 
 	// Also include any of this server's custom mounts when returning them.


### PR DESCRIPTION
This change resolves an issue in container where the user id is not found.

This will create a passwd file with a single line that is for the container user using the uid and gid of the pterodactyl user.

example passwd file contents  
`container:x:999:999::/home/container:/usr/sbin/nologin`