### PR TITLE
Update Dockerfile to build with golang 1.20.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1 (Build)
-FROM golang:1.19-alpine AS builder
+FROM golang:1.20.10-alpine AS builder
 
 ARG VERSION
 RUN apk add --update --no-cache git make


### PR DESCRIPTION
Update Dockerfile to build images with golang 1.20.10 to match the binary only releases.