### PR TITLE
Enforce the egg's file denylist more thoroughly

### DIFF
--- a/router/router_download.go
+++ b/router/router_download.go
@@ -78,6 +78,11 @@ func getDownloadFile(c *gin.Context) {
 		return
 	}
 
+	if err := s.Filesystem().IsIgnored(token.FilePath); err != nil {
+		middleware.CaptureAndAbort(c, err)
+		return
+	}
+
 	f, st, err := s.Filesystem().File(token.FilePath)
 	if err != nil {
 		middleware.CaptureAndAbort(c, err)

--- a/router/router_server_files.go
+++ b/router/router_server_files.go
@@ -31,6 +31,10 @@ import (
 func getServerFileContents(c *gin.Context) {
 	s := middleware.ExtractServer(c)
 	p := strings.TrimLeft(c.Query("file"), "/")
+	if err := s.Filesystem().IsIgnored(p); err != nil {
+		middleware.CaptureAndAbort(c, err)
+		return
+	}
 	f, st, err := s.Filesystem().File(p)
 	if err != nil {
 		middleware.CaptureAndAbort(c, err)
@@ -214,6 +218,9 @@ func postServerDeleteFiles(c *gin.Context) {
 			case <-ctx.Done():
 				return ctx.Err()
 			default:
+				if err := s.Filesystem().IsIgnored(pi); err != nil {
+					return err
+				}
 				return s.Filesystem().Delete(pi)
 			}
 		})
@@ -323,6 +330,11 @@ func postServerPullRemoteFile(c *gin.Context) {
 		FileName:  data.FileName,
 		UseHeader: data.UseHeader,
 	})
+
+	if err := s.Filesystem().IsIgnored(dl.Path()); err != nil {
+		middleware.CaptureAndAbort(c, err)
+		return
+	}
 
 	download := func() error {
 		s.Log().WithField("download_id", dl.Identifier).WithField("url", u.String()).Info("starting pull of remote file to disk")

--- a/server/filesystem/compress.go
+++ b/server/filesystem/compress.go
@@ -28,6 +28,11 @@ import (
 // and the compressed file will be placed at that location named
 // `archive-{date}.tar.gz`.
 func (fs *Filesystem) CompressFiles(dir string, paths []string) (ufs.FileInfo, error) {
+	for _, file := range paths {
+		if err := fs.IsIgnored(path.Join(dir, file)); err != nil {
+			return nil, err
+		}
+	}
 	a := &Archive{Filesystem: fs, BaseDirectory: dir, Files: paths}
 	d := path.Join(
 		dir,


### PR DESCRIPTION
The file denylist is not strictly enforced since Wings v1.11.9+. This PR adds extra checks where relevant to make sure that the file denylist is respected more appropriately.

Closes pterodactyl/panel#5042.