### PR TITLE
Handle Single File Compressed Files

### DIFF
--- a/server/filesystem/compress.go
+++ b/server/filesystem/compress.go
@@ -156,6 +156,7 @@ func (fs *Filesystem) DecompressFile(ctx context.Context, dir string, file strin
 	}
 
 	return fs.extractStream(ctx, extractStreamOptions{
+		FileName:  file,
 		Directory: dir,
 		Format:    format,
 		Reader:    input,
@@ -190,11 +191,48 @@ type extractStreamOptions struct {
 }
 
 func (fs *Filesystem) extractStream(ctx context.Context, opts extractStreamOptions) error {
-	// Decompress and extract archive
+
+	// See if it's a compressed archive, such as TAR or a ZIP
 	ex, ok := opts.Format.(archiver.Extractor)
 	if !ok {
+
+		// If not, check if it's a single-file compression, such as
+		// .log.gz, .sql.gz, and so on
+		de, ok := opts.Format.(archiver.Decompressor)
+		if !ok {
+			return nil
+		}
+
+		// Strip the compression suffix
+		p := filepath.Join(opts.Directory, strings.TrimSuffix(opts.FileName, opts.Format.Name()))
+
+		// Make sure it's not ignored
+		if err := fs.IsIgnored(p); err != nil {
+			return nil
+		}
+
+		reader, err := de.OpenReader(opts.Reader)
+		if err != nil {
+			return err
+		}
+		defer reader.Close()
+
+		// Open the file for creation/writing
+		f, err := fs.unixFS.OpenFile(p, ufs.O_WRONLY|ufs.O_CREATE, 0o644)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		// Write our file
+		if _, err := io.Copy(f, reader); err != nil {
+			return err
+		}
+
 		return nil
 	}
+
+	// Decompress and extract archive
 	return ex.Extract(ctx, opts.Reader, nil, func(ctx context.Context, f archiver.File) error {
 		if f.IsDir() {
 			return nil


### PR DESCRIPTION
This PR should allow single compressed files that aren't archives (such as `log.gz`) to be uncompressed.

As far as I can tell https://github.com/pterodactyl/wings/commit/f1c5bbd42d423986e7017b4f3c43057a1b7d1717 made it possible for `archiverFileSystem` to access the compressed files safely, but only `SpaceAvailableForDecompression` uses this; `DecompressFile` does not

This should work with all the compression types `mhold/archiver` supports

Should fix  https://github.com/pterodactyl/panel/issues/5034

