### PR TITLE
Correct Content-Type and add support for wider range of response codes in wings diagnostics

### DIFF
--- a/cmd/diagnostics.go
+++ b/cmd/diagnostics.go
@@ -229,8 +229,8 @@ func uploadToHastebin(hbUrl, content string) (string, error) {
 		return "", err
 	}
 	u.Path = path.Join(u.Path, "documents")
-	res, err := http.Post(u.String(), "plain/text", r)
-	if err != nil || res.StatusCode != 200 {
+	res, err := http.Post(u.String(), "text/plain", r)
+	if err != nil || res.StatusCode < 200 || res.StatusCode >= 300 {
 		fmt.Println("Failed to upload report to ", u.String(), err)
 		return "", err
 	}


### PR DESCRIPTION
`plain/text` isn't a valid type, this PR corrects it to `text/plain`. Some newer installs of haste-server throw errors because of this issue.

Also added support for a wider range of valid http return codes as some newer installs of haste-server return different codes such as 201 Accepted.

