### PR TITLE
server(filesystem): Fix sort position of directories

### DIFF
--- a/server/filesystem/filesystem.go
+++ b/server/filesystem/filesystem.go
@@ -480,9 +480,9 @@ func (fs *Filesystem) ListDirectory(p string) ([]Stat, error) {
 		case a.IsDir() && b.IsDir():
 			return 0
 		case a.IsDir():
-			return 1
-		default:
 			return -1
+		default:
+			return 1
 		}
 	})
 


### PR DESCRIPTION
Correct the sorting order so that directories are at the beginning as intended.
The current code incorrectly places directories at the end of the list.

Resolves: https://github.com/pterodactyl/panel/issues/5078

Before change: https://ptero.co/joqelihiti.json
After change: https://ptero.co/baloqaquwu.json