### PR TITLE
router(download): display the backup uuid on the error

### DIFF
--- a/router/router_download.go
+++ b/router/router_download.go
@@ -47,7 +47,7 @@ func getDownloadBackup(c *gin.Context) {
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			c.AbortWithStatusJSON(http.StatusNotFound, gin.H{
-				"error": "The requested backup was not found on this server.",
+        "error": "The requested backup with uuid: " + token.BackupUuid + " was not found on this server.",
 			})
 			return
 		}


### PR DESCRIPTION
Display the UUID of the backup request in the error sent to the client to simplify debugging.