### PR TITLE
fix: properly use base2 (1024, *bibyte) when calculating memory limits

### DIFF
--- a/environment/settings.go
+++ b/environment/settings.go
@@ -34,7 +34,7 @@ type Mount struct {
 // Limits is the build settings for a given server that impact docker container
 // creation and resource limits for a server instance.
 type Limits struct {
-	// The total amount of memory in megabytes that this server is allowed to
+	// The total amount of memory in mebibytes that this server is allowed to
 	// use on the host system.
 	MemoryLimit int64 `json:"memory_limit"`
 
@@ -70,6 +70,8 @@ func (l Limits) ConvertedCpuLimit() int64 {
 	return l.CpuLimit * 1000
 }
 
+const MEBIBYTES_TO_BYTES = 1024 * 1024
+
 // MemoryOverheadMultiplier sets the hard limit for memory usage to be 5% more
 // than the amount of memory assigned to the server. If the memory limit for the
 // server is < 4G, use 10%, if less than 2G use 15%. This avoids unexpected
@@ -79,7 +81,7 @@ func (l Limits) MemoryOverheadMultiplier() float64 {
 }
 
 func (l Limits) BoundedMemoryLimit() int64 {
-	return int64(math.Round(float64(l.MemoryLimit) * l.MemoryOverheadMultiplier() * 1_000_000))
+	return int64(math.Round(float64(l.MemoryLimit) * l.MemoryOverheadMultiplier() * MEBIBYTES_TO_BYTES))
 }
 
 // ConvertedSwap returns the amount of swap available as a total in bytes. This
@@ -90,7 +92,7 @@ func (l Limits) ConvertedSwap() int64 {
 		return -1
 	}
 
-	return (l.Swap * 1_000_000) + l.BoundedMemoryLimit()
+	return (l.Swap * MEBIBYTES_TO_BYTES) + l.BoundedMemoryLimit()
 }
 
 // ProcessLimit returns the process limit for a container. This is currently
@@ -105,7 +107,7 @@ func (l Limits) AsContainerResources() container.Resources {
 	pids := l.ProcessLimit()
 	resources := container.Resources{
 		Memory:            l.BoundedMemoryLimit(),
-		MemoryReservation: l.MemoryLimit * 1_000_000,
+		MemoryReservation: l.MemoryLimit * MEBIBYTES_TO_BYTES,
 		MemorySwap:        l.ConvertedSwap(),
 		BlkioWeight:       l.IoWeight,
 		OomKillDisable:    &l.OOMDisabled,

--- a/environment/settings.go
+++ b/environment/settings.go
@@ -70,8 +70,6 @@ func (l Limits) ConvertedCpuLimit() int64 {
 	return l.CpuLimit * 1000
 }
 
-const MEBIBYTES_TO_BYTES = 1024 * 1024
-
 // MemoryOverheadMultiplier sets the hard limit for memory usage to be 5% more
 // than the amount of memory assigned to the server. If the memory limit for the
 // server is < 4G, use 10%, if less than 2G use 15%. This avoids unexpected
@@ -81,7 +79,7 @@ func (l Limits) MemoryOverheadMultiplier() float64 {
 }
 
 func (l Limits) BoundedMemoryLimit() int64 {
-	return int64(math.Round(float64(l.MemoryLimit) * l.MemoryOverheadMultiplier() * MEBIBYTES_TO_BYTES))
+	return int64(math.Round(float64(l.MemoryLimit) * l.MemoryOverheadMultiplier() * 1024 * 1024))
 }
 
 // ConvertedSwap returns the amount of swap available as a total in bytes. This
@@ -92,7 +90,7 @@ func (l Limits) ConvertedSwap() int64 {
 		return -1
 	}
 
-	return (l.Swap * MEBIBYTES_TO_BYTES) + l.BoundedMemoryLimit()
+	return (l.Swap * 1024 * 1024) + l.BoundedMemoryLimit()
 }
 
 // ProcessLimit returns the process limit for a container. This is currently
@@ -107,7 +105,7 @@ func (l Limits) AsContainerResources() container.Resources {
 	pids := l.ProcessLimit()
 	resources := container.Resources{
 		Memory:            l.BoundedMemoryLimit(),
-		MemoryReservation: l.MemoryLimit * MEBIBYTES_TO_BYTES,
+		MemoryReservation: l.MemoryLimit * 1024 * 1024,
 		MemorySwap:        l.ConvertedSwap(),
 		BlkioWeight:       l.IoWeight,
 		OomKillDisable:    &l.OOMDisabled,


### PR DESCRIPTION
The Panel gives memory limits in mebibytes (MiB) but Wings considered they were megabytes (MB).