### PR TITLE
fix: user-defined labels not being passed to environment

### DIFF
--- a/server/update.go
+++ b/server/update.go
@@ -28,6 +28,7 @@ func (s *Server) SyncWithEnvironment() {
 		Mounts:      s.Mounts(),
 		Allocations: cfg.Allocations,
 		Limits:      cfg.Build,
+		Labels:      cfg.Labels,
 	})
 
 	// For Docker specific environments we also want to update the configured image


### PR DESCRIPTION
We were dropping the labels provided by the panel while updating the Settings struct