### PR TITLE
docker: Expose default SFTP port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ COPY --from=builder /etc/os-release /etc/os-release
 COPY --from=builder /app/wings /usr/bin/
 CMD [ "/usr/bin/wings", "--config", "/etc/pterodactyl/config.yml" ]
 
-EXPOSE 8080
+EXPOSE 8080 2022


### PR DESCRIPTION
This pull request adds the default SFTP port (2022) to the `EXPOSE` instruction in `Dockerfile`