### PR TITLE
Comment out the CA cert mounting from the docker-compose.example.yml

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -22,7 +22,8 @@ services:
       - "/var/lib/pterodactyl/:/var/lib/pterodactyl/"
       - "/var/log/pterodactyl/:/var/log/pterodactyl/"
       - "/tmp/pterodactyl/:/tmp/pterodactyl/"
-      - "/etc/ssl/certs:/etc/ssl/certs:ro"
+      # Uncomment and point at your systems ca-certificates bundle if the images included one does not work for you.
+      #- "/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro"
       # you may need /srv/daemon-data if you are upgrading from an old daemon
       #- "/srv/daemon-data/:/srv/daemon-data/"
       # Required for ssl if you use let's encrypt. uncomment to use.


### PR DESCRIPTION
This PR comments out the CA cert mount in the example docker compose file as the wings image is built on distroless and already includes a functioning CA cert bundle in the image.
This will make the image work properly no matter how the underlying OS has their cert bundling setup.

This was originally added back when the wings image was based on alpine and had a missing or outdated CA cert bundle. 

Ref https://github.com/pterodactyl/panel/issues/3096 and https://github.com/pterodactyl/wings/pull/154