### PR TITLE
fix: Symlinks not flagged as symlinks in file listing

### DIFF
--- a/server/filesystem/stat.go
+++ b/server/filesystem/stat.go
@@ -38,7 +38,7 @@ func (s *Stat) MarshalJSON() ([]byte, error) {
 		Size:      s.Size(),
 		Directory: s.IsDir(),
 		File:      !s.IsDir(),
-		Symlink:   s.Mode().Perm()&ufs.ModeSymlink != 0,
+		Symlink:   s.Mode().Type()&ufs.ModeSymlink != 0,
 		Mime:      s.Mimetype,
 	})
 }


### PR DESCRIPTION
Bitwise operation was comparing s.Mode().Perms() instead of s.Mode().Type()