### PR TITLE
Add missing Extraction type to fix backup restore

### DIFF
--- a/server/backup/backup.go
+++ b/server/backup/backup.go
@@ -22,6 +22,7 @@ import (
 var format = archives.CompressedArchive{
 	Compression: archives.Gz{},
 	Archival:    archives.Tar{},
+	Extraction:  archives.Tar{},
 }
 
 type AdapterType string


### PR DESCRIPTION
As eluded to here https://github.com/pterodactyl/panel/issues/5253#issuecomment-2543883613 and confirmed by Quinten the Extraction type is missing causing backup restores to fail.

I've tested this and confirmed it's working as expected with this patch.