### PR TITLE
ci: use correct variable for Git commit SHA in push workflow

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -44,8 +44,8 @@ jobs:
           CGO_ENABLED: 0
           SRC_PATH: github.com/pterodactyl/wings
         run: |
-          go build -v -trimpath -ldflags="-s -w -X ${SRC_PATH}/system.Version=dev-${GIT_COMMIT:0:7}" -o dist/wings ${SRC_PATH}
-          go build -v -trimpath -ldflags="-X ${SRC_PATH}/system.Version=dev-${GIT_COMMIT:0:7}" -o dist/wings_debug ${SRC_PATH}
+          go build -v -trimpath -ldflags="-s -w -X ${SRC_PATH}/system.Version=dev-${GITHUB_SHA:0:7}" -o dist/wings ${SRC_PATH}
+          go build -v -trimpath -ldflags="-X ${SRC_PATH}/system.Version=dev-${GITHUB_SHA:0:7}" -o dist/wings_debug ${SRC_PATH}
           chmod 755 dist/*
 
       - name: go test


### PR DESCRIPTION
Replace the non-existent `GIT_COMMIT` variable with the correct `GITHUB_SHA`. `GIT_COMMIT` seems to be a name used by the Git plugin for Jenkins and has been introduced in [this commit](https://github.com/pterodactyl/wings/commit/7a456dcac4ef33e175eeafc19dbf7890138876b0) by schrej.