### PR TITLE
Add basic logic to block actions to subusers after removing them from server

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -78,7 +78,7 @@ func Configure(m *wserver.Manager, client remote.Client) *gin.Engine {
 		server.POST("/reinstall", postServerReinstall)
 		server.POST("/sync", postServerSync)
 		server.POST("/ws/deny", postServerDenyWSTokens)
-		server.DELETE("/sftp/remove", deleteServerSFTPConnection)
+		server.DELETE("/sftp/disconnect", deleteServerSFTPConnection)
 
 		// This archive request causes the archive to start being created
 		// this should only be triggered by the panel.

--- a/router/router.go
+++ b/router/router.go
@@ -78,6 +78,7 @@ func Configure(m *wserver.Manager, client remote.Client) *gin.Engine {
 		server.POST("/reinstall", postServerReinstall)
 		server.POST("/sync", postServerSync)
 		server.POST("/ws/deny", postServerDenyWSTokens)
+		server.DELETE("/sftp/remove", deleteServerSFTPConnection)
 
 		// This archive request causes the archive to start being created
 		// this should only be triggered by the panel.

--- a/router/router_server.go
+++ b/router/router_server.go
@@ -261,3 +261,23 @@ func postServerDenyWSTokens(c *gin.Context) {
 
 	c.Status(http.StatusNoContent)
 }
+
+func deleteServerSFTPConnection(c *gin.Context) {
+	s := ExtractServer(c)
+
+	var data struct {
+		Username string `json:"username"`
+	}
+
+	if err := c.BindJSON(&data); err != nil {
+		return
+	}
+
+	for username, _ := range s.GetActiveSFTPConnections() {
+		if username == data.Username {
+			s.RemoveActiveSFTPConnection(username)
+		}
+	}
+
+	c.Status(http.StatusNoContent)
+}

--- a/router/router_server.go
+++ b/router/router_server.go
@@ -262,6 +262,7 @@ func postServerDenyWSTokens(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
+// Remove all SFTP connections for a specific user.
 func deleteServerSFTPConnection(c *gin.Context) {
 	s := ExtractServer(c)
 
@@ -275,7 +276,7 @@ func deleteServerSFTPConnection(c *gin.Context) {
 
 	for username, _ := range s.GetActiveSFTPConnections() {
 		if username == data.Username {
-			s.RemoveActiveSFTPConnection(username)
+			s.RemoveActiveSFTPConnection(username, nil)
 		}
 	}
 

--- a/router/router_server.go
+++ b/router/router_server.go
@@ -274,10 +274,11 @@ func deleteServerSFTPConnection(c *gin.Context) {
 		return
 	}
 
-	for username, _ := range s.GetActiveSFTPConnections() {
-		if username == data.Username {
-			s.RemoveActiveSFTPConnection(username, nil)
+	if activeSessions := s.GetActiveSFTPConnections()[data.Username]; activeSessions != nil {
+		for _, session := range activeSessions {
+			session.Close()
 		}
+		s.RemoveActiveSFTPConnection(data.Username, nil)
 	}
 
 	c.Status(http.StatusNoContent)

--- a/server/server.go
+++ b/server/server.go
@@ -371,10 +371,16 @@ func (s *Server) GetActiveSFTPConnections() map[string][]*sftp.RequestServer {
 }
 
 func (s *Server) RemoveActiveSFTPConnection(username string) {
+	s.Lock()
+	defer s.Unlock()
+
 	delete(s.activeSFTPConnections, username)
 }
 
 func (s *Server) AddActiveSFTPConnection(username string, conn *sftp.RequestServer) {
+	s.Lock()
+	defer s.Unlock()
+
 	if s.activeSFTPConnections == nil {
 		s.activeSFTPConnections = make(map[string][]*sftp.RequestServer)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/pkg/sftp"
 	"net/http"
 	"os"
 	"strings"
@@ -74,6 +75,8 @@ type Server struct {
 
 	logSink     *system.SinkPool
 	installSink *system.SinkPool
+
+	activeSFTPConnections map[string][]*sftp.RequestServer
 }
 
 // New returns a new server instance with a context and all of the default
@@ -361,4 +364,20 @@ func (s *Server) ToAPIResponse() APIResponse {
 		Utilization:   s.Proc(),
 		Configuration: *s.Config(),
 	}
+}
+
+func (s *Server) GetActiveSFTPConnections() map[string][]*sftp.RequestServer {
+	return s.activeSFTPConnections
+}
+
+func (s *Server) RemoveActiveSFTPConnection(username string) {
+	delete(s.activeSFTPConnections, username)
+}
+
+func (s *Server) AddActiveSFTPConnection(username string, conn *sftp.RequestServer) {
+	if s.activeSFTPConnections == nil {
+		s.activeSFTPConnections = make(map[string][]*sftp.RequestServer)
+	}
+
+	s.activeSFTPConnections[username] = append(s.activeSFTPConnections[username], conn)
 }

--- a/sftp/handler.go
+++ b/sftp/handler.go
@@ -294,11 +294,6 @@ func (h *Handler) can(permission string) bool {
 	if h.server.IsSuspended() {
 		return false
 	}
-	activeSFTPConnections := h.server.GetActiveSFTPConnections()
-
-	if activeSFTPConnections[h.username] == nil {
-		return false
-	}
 
 	for _, p := range h.permissions {
 		// If we match the permission specifically, or the user has been granted the "*"

--- a/sftp/handler.go
+++ b/sftp/handler.go
@@ -30,10 +30,10 @@ type Handler struct {
 	server      *server.Server
 	fs          *filesystem.Filesystem
 	events      *eventHandler
-	username    string
 	permissions []string
 	logger      *log.Entry
 	ro          bool
+	username    string
 }
 
 // NewHandler returns a new connection handler for the SFTP server. This allows a given user

--- a/sftp/server.go
+++ b/sftp/server.go
@@ -171,10 +171,10 @@ func (c *SFTPServer) AcceptInbound(conn net.Conn, config *ssh.ServerConfig) erro
 			return errors.WithStackIf(err)
 		}
 		rs := sftp.NewRequestServer(channel, handler.Handlers())
-		srv.AddActiveSFTPConnection(uuid, rs)
+		srv.AddActiveSFTPConnection(sconn.Conn.User(), sconn)
 
 		if err := rs.Serve(); err == io.EOF {
-			srv.RemoveActiveSFTPConnection(uuid, rs)
+			srv.RemoveActiveSFTPConnection(sconn.Conn.User(), sconn)
 			_ = rs.Close()
 		}
 	}

--- a/sftp/server.go
+++ b/sftp/server.go
@@ -171,7 +171,9 @@ func (c *SFTPServer) AcceptInbound(conn net.Conn, config *ssh.ServerConfig) erro
 			return errors.WithStackIf(err)
 		}
 		rs := sftp.NewRequestServer(channel, handler.Handlers())
+		srv.AddActiveSFTPConnection(sconn.Conn.User(), rs)
 		if err := rs.Serve(); err == io.EOF {
+			srv.RemoveActiveSFTPConnection(uuid)
 			_ = rs.Close()
 		}
 	}

--- a/sftp/server.go
+++ b/sftp/server.go
@@ -171,9 +171,10 @@ func (c *SFTPServer) AcceptInbound(conn net.Conn, config *ssh.ServerConfig) erro
 			return errors.WithStackIf(err)
 		}
 		rs := sftp.NewRequestServer(channel, handler.Handlers())
-		srv.AddActiveSFTPConnection(sconn.Conn.User(), rs)
+		srv.AddActiveSFTPConnection(uuid, rs)
+
 		if err := rs.Serve(); err == io.EOF {
-			srv.RemoveActiveSFTPConnection(uuid)
+			srv.RemoveActiveSFTPConnection(uuid, rs)
 			_ = rs.Close()
 		}
 	}


### PR DESCRIPTION
This PR adds simple logic that allows to block actions for subusers that have SFTP connections after removing from server. 

Frontend implementation: https://github.com/pterodactyl/panel/pull/5283