### PR TITLE
Add a config bool to disable docker interface binding.

### DIFF
--- a/config/config_docker.go
+++ b/config/config_docker.go
@@ -25,6 +25,10 @@ type DockerNetworkConfiguration struct {
 	// with any other interfaces in use by Docker or on the system.
 	Interface string `default:"172.18.0.1" json:"interface" yaml:"interface"`
 
+	// DisableInterfaceBinding determines whether containers should bind to a specific
+	// interface. If true, containers will bind to all interfaces.
+	DisableInterfaceBinding bool `default:"false" json:"disable_interface_binding" yaml:"disable_interface_binding"`
+
 	// The DNS settings for containers.
 	Dns []string `default:"[\"1.1.1.1\", \"1.0.0.1\"]"`
 

--- a/environment/allocations.go
+++ b/environment/allocations.go
@@ -66,6 +66,7 @@ func (a *Allocations) Bindings() nat.PortMap {
 // server to operate on a local address while still being accessible by other containers.
 func (a *Allocations) DockerBindings() nat.PortMap {
 	iface := config.Get().Docker.Network.Interface
+	disableBinding := config.Get().Docker.Network.DisableInterfaceBinding
 
 	out := a.Bindings()
 	// Loop over all the bindings for this container, and convert any that reference 127.0.0.1
@@ -73,6 +74,15 @@ func (a *Allocations) DockerBindings() nat.PortMap {
 	// trying to do when creating servers.
 	for p, binds := range out {
 		for i, alloc := range binds {
+			// If interface binding is disabled, set HostIP to empty string
+			if disableBinding {
+				out[p][i] = nat.PortBinding{
+					HostIP:   "",
+					HostPort: alloc.HostPort,
+				}
+				continue
+			}
+
 			if alloc.HostIP != "127.0.0.1" {
 				continue
 			}


### PR DESCRIPTION
false by default
useful for setups where binding to a specific interface causes problems (eg PROXY protocol)