### PR TITLE
Prevent overwriting config.yaml when ignore_panel_config_updates is true

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -436,7 +436,11 @@ func GetJwtAlgorithm() *jwt.HMACSHA {
 func WriteToDisk(c *Configuration) error {
 	_writeLock.Lock()
 	defer _writeLock.Unlock()
-
+	
+	// Check if panel config updates should be ignored
+	if c.IgnorePanelConfigUpdates {
+		return nil // Skip writing to disk if flag is set
+	}
 	//goland:noinspection GoVetCopyLock
 	ccopy := *c
 	// If debugging is set with the flag, don't save that to the configuration file,


### PR DESCRIPTION
Prevent overwriting config.yaml when ignore_panel_config_updates is true

- Added a check in WriteToDisk to skip writing if IgnorePanelConfigUpdates is set.
- Preserves manual changes to config.yaml on Wings restart.

Fixes [#5386](https://github.com/pterodactyl/panel/issues/5386)
