### PR TITLE
feat: add ServerUUID label to containers

### DIFF
--- a/environment/docker/container.go
+++ b/environment/docker/container.go
@@ -172,6 +172,7 @@ func (e *Environment) Create() error {
 	}
 	labels["Service"] = "Pterodactyl"
 	labels["ContainerType"] = "server_process"
+	labels["ServerUUID"] = e.Id
 
 	conf := &container.Config{
 		Hostname:     e.Id,

--- a/server/install.go
+++ b/server/install.go
@@ -409,6 +409,7 @@ func (ip *InstallationProcess) Execute() (string, error) {
 		Labels: map[string]string{
 			"Service":       "Pterodactyl",
 			"ContainerType": "server_installer",
+			"ServerUUID":    ip.Server.ID(),
 		},
 	}
 


### PR DESCRIPTION
Add ServerUUID label to both server and installer containers for improved container identification and filtering using Docker's native label filtering capabilities.

This enables querying containers by server ID independently of container names and supports multi-dimensional filtering by combining with existing Service and ContainerType labels.