### PR TITLE
Add support for the ppc64le architecture

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -59,7 +59,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/ppc64le
           build-args: |
             VERSION=${{ steps.build_info.outputs.version_tag }}
           labels: ${{ steps.docker_meta.outputs.labels }}
@@ -72,7 +72,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/ppc64le
           build-args: |
             VERSION=dev-${{ steps.build_info.outputs.short_sha }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-24.04]
         go: ["1.23.7", "1.24.1"]
         goos: [linux]
-        goarch: [amd64, arm64]
+        goarch: [amd64, arm64, ppc64le]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,8 @@ jobs:
           chmod 755 dist/wings_linux_amd64
           GOARCH=arm64 go build -o dist/wings_linux_arm64 -v -trimpath -ldflags="-s -w -X github.com/pterodactyl/wings/system.Version=${REF:11}" github.com/pterodactyl/wings
           chmod 755 dist/wings_linux_arm64
+          GOARCH=ppc64le go build -o dist/wings_linux_ppc64le -v -trimpath -ldflags="-s -w -X github.com/pterodactyl/wings/system.Version=${REF:11}" github.com/pterodactyl/wings
+          chmod 755 dist/wings_linux_ppc64le
 
       - name: Extract changelog
         env:
@@ -41,8 +43,9 @@ jobs:
         run: |
           SUM=`cd dist && sha256sum wings_linux_amd64`
           SUM2=`cd dist && sha256sum wings_linux_arm64`
-          echo -e "\n#### SHA256 Checksum\n\`\`\`\n$SUM\n$SUM2\n\`\`\`\n" >> ./RELEASE_CHANGELOG
-          echo -e "$SUM\n$SUM2" > checksums.txt
+          SUM3=$(cd dist && sha256sum wings_linux_ppc64le)
+          echo -e "\n#### SHA256 Checksum\n\`\`\`\n$SUM\n$SUM2\n$SUM3\n\`\`\`\n" >> ./RELEASE_CHANGELOG
+          echo -e "$SUM\n$SUM2\n$SUM3" > checksums.txt
 
       - name: Create release branch
         env:

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ GIT_HEAD = $(shell git rev-parse HEAD | head -c8)
 build:
 	GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -gcflags "all=-trimpath=$(pwd)" -o build/wings_linux_amd64 -v wings.go
 	GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -gcflags "all=-trimpath=$(pwd)" -o build/wings_linux_arm64 -v wings.go
+	GOOS=linux GOARCH=ppc64le go build -ldflags="-s -w" -gcflags "all=-trimpath=$(pwd)" -o build/wings_linux_ppc64le -v wings.go
 
 debug:
 	go build -ldflags="-X github.com/pterodactyl/wings/system.Version=$(GIT_HEAD)"


### PR DESCRIPTION
This adds support for building the docker images for the `ppc64le` architecture. This is used on IBM POWER servers, and also on high end workstations like the Talos II from Raptor Computing Systems.

I've been running a bunch of Minecraft servers manually on my Talos II for years, and would love to migrate them all to Pterodactyl!

I've opened a PR to build the required Docker images in the `yolks` repo: https://github.com/pterodactyl/yolks/pull/62

After modifying the vanilla Minecraft egg to point to my installer docker image, uploading it to the panel, and starting wings built for `ppc64e`, the server works perfectly! Wings didn't even require any code changes to work on this architecture, which is awesome.

Please let me know if you have any questions or comments; I am happy more than happy to answer. 😄 

Some screenshots of everything running:

<img width="1799" height="1129" alt="ppc64le_panel" src="https://github.com/user-attachments/assets/be3ad605-7e9d-480a-a954-819ca7811f6f" />
<img width="1926" height="879" alt="talos_system" src="https://github.com/user-attachments/assets/842295b3-0427-4fc1-a115-5197876aa8c6" />
<img width="1454" height="824" alt="Screen Shot 2025-11-09 at 5 01 08 AM" src="https://github.com/user-attachments/assets/ac0adaf1-abf9-42c6-8c27-04b0f61c3d17" />

