### PR TITLE
Close all open websocket connections when server is suspended

### DIFF
--- a/router/router_server_ws.go
+++ b/router/router_server_ws.go
@@ -102,7 +102,7 @@ func getServerWebsocket(c *gin.Context) {
 		go func(msg websocket.Message) {
 			if err := handler.HandleInbound(ctx, msg); err != nil {
 				if errors.Is(err, server.ErrSuspended) {
-					_ = handler.Connection.WriteMessage(ws.CloseMessage, ws.FormatCloseMessage(4409, "server is suspended"))
+					cancel()
 				} else {
 					_ = handler.SendErrorJson(msg, err)
 				}

--- a/router/router_server_ws.go
+++ b/router/router_server_ws.go
@@ -3,12 +3,13 @@ package router
 import (
 	"context"
 	"encoding/json"
-	"net/http"
 
+	"emperror.dev/errors"
 	"github.com/gin-gonic/gin"
 	ws "github.com/gorilla/websocket"
 	"github.com/pterodactyl/wings/router/middleware"
 	"github.com/pterodactyl/wings/router/websocket"
+	"github.com/pterodactyl/wings/server"
 )
 
 var expectedCloseCodes = []int{
@@ -23,12 +24,6 @@ var expectedCloseCodes = []int{
 func getServerWebsocket(c *gin.Context) {
 	manager := middleware.ExtractManager(c)
 	s, _ := manager.Get(c.Param("server"))
-
-	if s.IsSuspended() {
-		c.AbortWithStatusJSON(http.StatusConflict, gin.H{"error": "Server is suspended and will not accept websocket connections."})
-
-		return
-	}
 
 	// Create a context that can be canceled when the user disconnects from this
 	// socket that will also cancel listeners running in separate threads. If the
@@ -64,6 +59,8 @@ func getServerWebsocket(c *gin.Context) {
 
 	go func() {
 		select {
+		case <-ctx.Done():
+			return
 		// If the server is deleted we need to send a close message to the connected client
 		// so that they disconnect since there will be no more events sent along. Listen for
 		// the request context being closed to break this loop, otherwise this routine will
@@ -73,6 +70,16 @@ func getServerWebsocket(c *gin.Context) {
 			break
 		}
 	}()
+
+	// Due to how websockets are handled we need to connect to the socket
+	// and _then_ abort it if the server is suspended. You cannot capture
+	// the HTTP response in the websocket client, thus we connect and then
+	// immediately close with failure.
+	if s.IsSuspended() {
+		_ = handler.Connection.WriteMessage(ws.CloseMessage, ws.FormatCloseMessage(4409, "server is suspended"))
+
+		return
+	}
 
 	for {
 		j := websocket.Message{}
@@ -94,7 +101,11 @@ func getServerWebsocket(c *gin.Context) {
 
 		go func(msg websocket.Message) {
 			if err := handler.HandleInbound(ctx, msg); err != nil {
-				_ = handler.SendErrorJson(msg, err)
+				if errors.Is(err, server.ErrSuspended) {
+					_ = handler.Connection.WriteMessage(ws.CloseMessage, ws.FormatCloseMessage(4409, "server is suspended"))
+				} else {
+					_ = handler.SendErrorJson(msg, err)
+				}
 			}
 		}(j)
 	}

--- a/router/router_server_ws.go
+++ b/router/router_server_ws.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	ws "github.com/gorilla/websocket"
@@ -50,20 +49,27 @@ func getServerWebsocket(c *gin.Context) {
 	handler.Logger().Debug("opening connection to server websocket")
 	defer s.Websockets().Remove(handler.Uuid())
 
-	// If the server is deleted we need to send a close message to the connected client
-	// so that they disconnect since there will be no more events sent along. Listen for
-	// the request context being closed to break this loop, otherwise this routine will
-	// be left hanging in the background.
 	go func() {
 		select {
+		// When the main context is canceled (through disconnect, server deletion, or server
+		// suspension) close the connection itself.
 		case <-ctx.Done():
 			handler.Logger().Debug("closing connection to server websocket")
 			if err := handler.Connection.Close(); err != nil {
 				handler.Logger().WithError(err).Error("failed to close websocket connection")
 			}
 			break
+		}
+	}()
+
+	go func() {
+		select {
+		// If the server is deleted we need to send a close message to the connected client
+		// so that they disconnect since there will be no more events sent along. Listen for
+		// the request context being closed to break this loop, otherwise this routine will
+		// be left hanging in the background.
 		case <-s.Context().Done():
-			_ = handler.Connection.WriteControl(ws.CloseMessage, ws.FormatCloseMessage(ws.CloseGoingAway, "server deleted"), time.Now().Add(time.Second*5))
+			cancel()
 			break
 		}
 	}()

--- a/router/router_server_ws.go
+++ b/router/router_server_ws.go
@@ -3,11 +3,11 @@ package router
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	ws "github.com/gorilla/websocket"
-
 	"github.com/pterodactyl/wings/router/middleware"
 	"github.com/pterodactyl/wings/router/websocket"
 )
@@ -25,6 +25,12 @@ func getServerWebsocket(c *gin.Context) {
 	manager := middleware.ExtractManager(c)
 	s, _ := manager.Get(c.Param("server"))
 
+	if s.IsSuspended() {
+		c.AbortWithStatusJSON(http.StatusConflict, gin.H{"error": "Server is suspended and will not accept websocket connections."})
+
+		return
+	}
+
 	// Create a context that can be canceled when the user disconnects from this
 	// socket that will also cancel listeners running in separate threads. If the
 	// connection itself is terminated listeners using this context will also be
@@ -37,17 +43,12 @@ func getServerWebsocket(c *gin.Context) {
 		middleware.CaptureAndAbort(c, err)
 		return
 	}
-	defer handler.Connection.Close()
 
 	// Track this open connection on the server so that we can close them all programmatically
 	// if the server is deleted.
 	s.Websockets().Push(handler.Uuid(), &cancel)
 	handler.Logger().Debug("opening connection to server websocket")
-
-	defer func() {
-		s.Websockets().Remove(handler.Uuid())
-		handler.Logger().Debug("closing connection to server websocket")
-	}()
+	defer s.Websockets().Remove(handler.Uuid())
 
 	// If the server is deleted we need to send a close message to the connected client
 	// so that they disconnect since there will be no more events sent along. Listen for
@@ -56,6 +57,10 @@ func getServerWebsocket(c *gin.Context) {
 	go func() {
 		select {
 		case <-ctx.Done():
+			handler.Logger().Debug("closing connection to server websocket")
+			if err := handler.Connection.Close(); err != nil {
+				handler.Logger().WithError(err).Error("failed to close websocket connection")
+			}
 			break
 		case <-s.Context().Done():
 			_ = handler.Connection.WriteControl(ws.CloseMessage, ws.FormatCloseMessage(ws.CloseGoingAway, "server deleted"), time.Now().Add(time.Second*5))

--- a/router/websocket/websocket.go
+++ b/router/websocket/websocket.go
@@ -287,6 +287,10 @@ func (h *Handler) HandleInbound(ctx context.Context, m Message) error {
 		}
 	}
 
+	if h.server.IsSuspended() {
+		return server.ErrSuspended
+	}
+
 	switch m.Event {
 	case AuthenticationEvent:
 		{

--- a/server/server.go
+++ b/server/server.go
@@ -199,6 +199,11 @@ func (s *Server) Sync() error {
 
 	s.SyncWithEnvironment()
 
+	// If the server is suspended immediately disconnect all open websocket connections.
+	if s.IsSuspended() {
+		s.Websockets().CancelAll()
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Ensures that all connections close immediately when a server is suspended or deleted. If for whatever reason a message is able to make it to the handler, it will immediately fail without processing if the server is suspended as well.

We now return `4409` as the message code when closing due to a suspension so that the client knows to not attempt reconnection.

associated https://github.com/pterodactyl/panel/pull/5464
resolves https://github.com/pterodactyl/panel/issues/5281