### PR TITLE
Correctly block reconnection to a websocket when revoking authorization

### DIFF
--- a/router/router_server.go
+++ b/router/router_server.go
@@ -246,7 +246,8 @@ func deleteServer(c *gin.Context) {
 // Adds any of the JTIs passed through in the body to the deny list for the websocket
 // preventing any JWT generated before the current time from being used to connect to
 // the socket or send along commands.
-// @deprecated superceded by /api/revoke
+//
+// deprecated: prefer /api/deauthorize-user
 func postServerDenyWSTokens(c *gin.Context) {
 	var data struct {
 		JTIs []string `json:"jtis"`

--- a/router/router_system.go
+++ b/router/router_system.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/gin-gonic/gin"
+	"github.com/pterodactyl/wings/router/tokens"
 
 	"github.com/pterodactyl/wings/config"
 	"github.com/pterodactyl/wings/router/middleware"
@@ -171,12 +172,14 @@ func postDeauthorizeUser(c *gin.Context) {
 	if len(data.Servers) > 0 {
 		for _, uuid := range data.Servers {
 			if s, ok := m.Get(uuid); ok {
+				tokens.DenyForServer(s.ID(), data.User)
 				s.Websockets().CancelAll()
 				s.Sftp().Cancel(data.User)
 			}
 		}
 	} else {
 		for _, s := range m.All() {
+			tokens.DenyForServer(s.ID(), data.User)
 			s.Websockets().CancelAll()
 			s.Sftp().Cancel(data.User)
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -201,7 +201,10 @@ func (s *Server) Sync() error {
 	s.SyncWithEnvironment()
 
 	// If the server is suspended immediately disconnect all open websocket connections
-	// and any connected SFTP clients.
+	// and any connected SFTP clients. We don't need to worry about revoking any JWTs
+	// here since they'll be blocked from re-connecting to the websocket anyways. This
+	// just forces the client to disconnect and attempt to reconnect (rather than waiting
+	// on them to send a message and hit that disconnect logic).
 	if s.IsSuspended() {
 		s.Websockets().CancelAll()
 		s.Sftp().CancelAll()


### PR DESCRIPTION
The previously comitted logic did correctly disconnect the user from the websocket, but missed blocking re-connecting with the same token. This updated logic correctly tracks the time of revocation and prevents any JWT issued to that user for that server before the revocation time from being re-used.

This was simpler than having to update the Panel to send along a bunch of JTIs and feels less error prone. I want to clean this up a lot, but it'll be a breaking change so we'll do it as a 2.0 release when we can safely do all of that.