### PR TITLE
feat: add mount for /etc/machine-id for servers 

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -197,9 +197,9 @@ func rootCmdRun(cmd *cobra.Command, _ []string) {
 	for _, serv := range manager.All() {
 		s := serv
 
-		// For each server we encounter make sure the root data directory exists.
-		if err := s.EnsureDataDirectoryExists(); err != nil {
-			s.Log().Error("could not create root data directory for server: not loading server...")
+		// For each server ensure the minimal environment is configured for the server.
+		if err := s.CreateEnvironment(); err != nil {
+			s.Log().Error("could create base environment for server...")
 			continue
 		}
 

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1741352980,
-        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
+        "lastModified": 1768135262,
+        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
+        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741379970,
-        "narHash": "sha256-Wh7esNh7G24qYleLvgOSY/7HlDUzWaL/n4qzlBePpiw=",
+        "lastModified": 1768127708,
+        "narHash": "sha256-1Sm77VfZh3mU0F5OqKABNLWxOuDeHIlcFjsXeeiPazs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "36fd87baa9083f34f7f5027900b62ee6d09b1f2f",
+        "rev": "ffbc9f8cbaacfb331b6017d5a5abb21a492c9a38",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1740877520,
-        "narHash": "sha256-oiwv/ZK/2FhGxrCkQkB83i7GnWXPPLzoqFHpDD3uYpk=",
+        "lastModified": 1765674936,
+        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "147dee35aab2193b174e4c0868bd80ead5ce755c",
+        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739829690,
-        "narHash": "sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU=",
+        "lastModified": 1768158989,
+        "narHash": "sha256-67vyT1+xClLldnumAzCTBvU0jLZ1YBcf4vANRWP3+Ak=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "3d0579f5cc93436052d94b73925b48973a104204",
+        "rev": "e96d59dff5c0d7fddb9d113ba108f03c3ef99eca",
         "type": "github"
       },
       "original": {

--- a/server/mounts.go
+++ b/server/mounts.go
@@ -29,17 +29,30 @@ func (s *Server) Mounts() []environment.Mount {
 		},
 	}
 
+	cfg := config.Get()
+
 	// Handle mounting a generated `/etc/passwd` if the feature is enabled.
-	if passwd := config.Get().System.Passwd; passwd.Enable {
-		s.Log().WithFields(log.Fields{"source_path": passwd.Directory}).Info("mouting generated /etc/{group,passwd} to workaround UID/GID issues")
+	if cfg.System.Passwd.Enable {
+		s.Log().WithFields(log.Fields{"source_path": cfg.System.Passwd.Directory}).Info("mouting generated /etc/{group,passwd} to workaround UID/GID issues")
 		m = append(m, environment.Mount{
-			Source:   filepath.Join(passwd.Directory, "group"),
+			Source:   filepath.Join(cfg.System.Passwd.Directory, "group"),
 			Target:   "/etc/group",
 			ReadOnly: true,
 		})
 		m = append(m, environment.Mount{
-			Source:   filepath.Join(passwd.Directory, "passwd"),
+			Source:   filepath.Join(cfg.System.Passwd.Directory, "passwd"),
 			Target:   "/etc/passwd",
+			ReadOnly: true,
+		})
+	}
+
+	if cfg.System.MachineID.Enable {
+		// Hytale wants a machine-id in order to encrypt tokens for the server.
+		// So add a mount to `/etc/machine-id` to a source that contains the
+		// server's UUID without any dashes.
+		m = append(m, environment.Mount{
+			Source:   filepath.Join(cfg.System.MachineID.Directory, s.ID()),
+			Target:   "/etc/machine-id",
 			ReadOnly: true,
 		})
 	}


### PR DESCRIPTION
Hytale wants a `/etc/machine-id` file when persisting the auth state of the server for whatever reason. Not sure of the exact purpose or security of this, but nonetheless, we need it if we want to not require users to re-auth their server after every restart.