### PR TITLE
Add device interfaces to Docker.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,28 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.20'
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...

--- a/config/config_docker.go
+++ b/config/config_docker.go
@@ -48,6 +48,22 @@ type DockerConfiguration struct {
 	// for containers run through the daemon.
 	Network DockerNetworkConfiguration `json:"network" yaml:"network"`
 
+	// Devices defines additional devices that should be passed through to all
+	// containers managed by Wings.
+	//
+	// Each entry should be in the format:
+	//   "/host/path:/container/path:permissions"
+	//
+	// The permissions segment is optional and will default to "rwm" when not
+	// provided. For example, to expose KVM to all containers you can use:
+	//   "/dev/kvm:/dev/kvm:rwm"
+	//
+	// This maps directly to Docker's DeviceMapping definition.
+	//
+	// If this list is empty, Wings will automatically add KVM (`/dev/kvm`) to
+	// containers when it exists on the host.
+	Devices []string `json:"devices" yaml:"devices"`
+
 	// Domainname is the Docker domainname for all containers.
 	Domainname string `default:"" json:"domainname" yaml:"domainname"`
 

--- a/environment/docker/container.go
+++ b/environment/docker/container.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -258,6 +259,9 @@ func (e *Environment) Create() error {
 		NetworkMode: networkMode,
 		UsernsMode:  container.UsernsMode(cfg.Docker.UsernsMode),
 	}
+	
+	// Attach device mappings (e.g. /dev/kvm) via container resources.
+	hostConf.Resources.Devices = convertDevices(cfg.Docker.Devices)
 
 	if _, err := e.client.ContainerCreate(ctx, conf, hostConf, nil, nil, e.Id); err != nil {
 		return errors.Wrap(err, "environment/docker: failed to create container")
@@ -449,5 +453,54 @@ func (e *Environment) convertMounts() []mount.Mount {
 			ReadOnly: m.ReadOnly,
 		}
 	}
+	return out
+}
+
+// convertDevices converts a list of Docker device strings into DeviceMapping
+// structs that can be attached to a container's HostConfig.
+//
+// Each device string should be in the form:
+//   "/host/path:/container/path:permissions"
+//
+// The permissions segment is optional and will default to "rwm" when omitted.
+func convertDevices(devices []string) []container.DeviceMapping {
+	// If no devices were explicitly configured, but /dev/kvm exists on the host,
+	// pass it through by default. This is a safe no-op on systems without KVM.
+	if len(devices) == 0 {
+		if _, err := os.Stat("/dev/kvm"); err == nil {
+			devices = []string{"/dev/kvm:/dev/kvm:rwm"}
+		}
+	}
+
+	out := make([]container.DeviceMapping, 0, len(devices))
+	for _, d := range devices {
+		if d == "" {
+			continue
+		}
+
+		parts := strings.Split(d, ":")
+		if len(parts) < 2 {
+			// Invalid device definition; skip it rather than erroring out.
+			continue
+		}
+
+		hostPath := parts[0]
+		containerPath := parts[1]
+		if hostPath == "" || containerPath == "" {
+			continue
+		}
+
+		perms := "rwm"
+		if len(parts) >= 3 && parts[2] != "" {
+			perms = parts[2]
+		}
+
+		out = append(out, container.DeviceMapping{
+			PathOnHost:        hostPath,
+			PathInContainer:   containerPath,
+			CgroupPermissions: perms,
+		})
+	}
+
 	return out
 }


### PR DESCRIPTION
I've added support for external devices because the default host doesn't enable them.Users will be able to mount kernel-related devices, for example.       /dev/binder
   * /dev/ashmem
   * /lib/modules
   * /dev/kvm
Furthermore, users can add a private network, and KVM mount support means that high-performance qemu virtual machines can be run because they share the same system kernel. 