### PR TITLE
Fix file path handling in download router

### DIFF
--- a/router/router_download.go
+++ b/router/router_download.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"errors"
 	"net/http"
+	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -81,6 +83,12 @@ func getDownloadFile(c *gin.Context) {
 		return
 	}
 
+	filePath, err := url.QueryUnescape(token.FilePath)
+	if err != nil {
+		middleware.CaptureAndAbort(c, err)
+		return
+	}
+
 	s, ok := manager.Get(token.ServerUuid)
 	if !ok || !token.IsUniqueRequest() {
 		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{
@@ -89,7 +97,7 @@ func getDownloadFile(c *gin.Context) {
 		return
 	}
 
-	f, st, err := s.Filesystem().File(token.FilePath)
+	f, st, err := s.Filesystem().File(filePath)
 	if err != nil {
 		middleware.CaptureAndAbort(c, err)
 		return
@@ -103,7 +111,8 @@ func getDownloadFile(c *gin.Context) {
 	}
 
 	c.Header("Content-Length", strconv.Itoa(int(st.Size())))
-	c.Header("Content-Disposition", "attachment; filename="+strconv.Quote(st.Name()))
+	filename := filepath.Base(filePath)
+	c.Header("Content-Disposition", "attachment; filename="+strconv.Quote(filename))
 	c.Header("Content-Type", "application/octet-stream")
 
 	_, _ = bufio.NewReader(f).WriteTo(c.Writer)


### PR DESCRIPTION
This pull request improves how file downloads are handled in the `getDownloadFile` function, focusing on safer and more accurate processing of file paths and filenames. The main changes include decoding URL-encoded file paths, extracting the correct filename for the download header, and updating imports to support these changes.

**File path handling and download improvements:**

* Decoded the URL-encoded file path from the download token using `url.QueryUnescape` to ensure correct file access and prevent issues with encoded characters.
* Updated the call to `s.Filesystem().File` to use the decoded `filePath` instead of the original token value, ensuring the correct file is accessed.
* Used `filepath.Base` to extract the filename from the full file path for the `Content-Disposition` header, ensuring the downloaded file has the correct name regardless of the original path.

**Dependency updates:**

* Added imports for `net/url` and `path/filepath` to support URL decoding and filename extraction.

🔗 Linked Issues: [#5256](https://github.com/pterodactyl/panel/issues/5256)