### PR TITLE
Remove deprecated version in compose file

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   wings:
     image: ghcr.io/pterodactyl/wings:latest


### PR DESCRIPTION
Same as https://github.com/pterodactyl/panel/pull/5498 but for wings.

> This minor change removes the deprecated `version` property from the Docker Compose file to avoid the warning when running it, aligning it with current best practices and recommendations.