### PR TITLE
Fix version command output format

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,7 +63,7 @@ var versionCommand = &cobra.Command{
 	Use:   "version",
 	Short: "Prints the current executable version and exits.",
 	Run: func(cmd *cobra.Command, _ []string) {
-		fmt.Printf("wings v%s\nCopyright © 2018 - %d Dane Everitt & Contributors\n", system.Version, time.Now().Year())
+		fmt.Printf("wings %s\nCopyright © 2018 - %d Dane Everitt & Contributors\n", system.Version, time.Now().Year())
 	},
 }
 


### PR DESCRIPTION
%v already outputs like 'v1.12.1' so using v%v outputs 'vv1.12.1'