### PR TITLE
fix(parser): return error for unknown parser type

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -215,7 +215,10 @@ func (f *ConfigurationFile) Parse(file ufs.File) error {
 		err = f.parseIniFile(file)
 	case Xml:
 		err = f.parseXmlFile(file)
+	default:
+		return errors.Errorf("parser: unknown parser type %q", f.Parser)
 	}
+
 	return err
 }
 


### PR DESCRIPTION
Previously, if the parser type did not match any valid types, Parse would silently do nothing and return nil as if it succeeded. This made it easy to miss typos or invalid parser types.

Now, an unknown parser type will return an error, making it easier to catch mistakes.