### PR TITLE
fix: Directories created via panel are owned by root:root

### DIFF
--- a/server/filesystem/compress.go
+++ b/server/filesystem/compress.go
@@ -272,12 +272,22 @@ func (fs *Filesystem) extractStream(ctx context.Context, opts extractStreamOptio
 		// Create directories explicitly; an empty one has no file to create it
 		// implicitly and would otherwise be dropped during extraction.
 		if f.IsDir() {
+			// Fetch all directories that are due to be created by MkdirAll so
+			// we can chown them after Touch creates them.
+			createdDirs, _ := fs.pendingDirs(p)
+
 			if err := fs.unixFS.MkdirAll(p, 0o755); err != nil {
 				return wrapError(err, opts.FileName)
 			}
-			if err := fs.chownRecursiveParents(p); err != nil {
-				return wrapError(err, opts.FileName)
-		}
+			
+			// Chown any parent directories that Touch created above so they are owned
+			// by the server user instead of the user Wings runs as.
+			for _, dir := range createdDirs {
+				if err := fs.chownFile(dir); err != nil {
+					return wrapError(err, opts.FileName)
+				}
+			}
+			
 			return nil
 		}
 		r, err := f.Open()

--- a/server/filesystem/compress.go
+++ b/server/filesystem/compress.go
@@ -275,6 +275,9 @@ func (fs *Filesystem) extractStream(ctx context.Context, opts extractStreamOptio
 			if err := fs.unixFS.MkdirAll(p, 0o755); err != nil {
 				return wrapError(err, opts.FileName)
 			}
+			if err := fs.chownRecursiveParents(p); err != nil {
+				return wrapError(err, opts.FileName)
+		}
 			return nil
 		}
 		r, err := f.Open()

--- a/server/filesystem/filesystem.go
+++ b/server/filesystem/filesystem.go
@@ -182,6 +182,9 @@ func (fs *Filesystem) Write(p string, r io.Reader, newSize int64, mode ufs.FileM
 	if err := fs.chownFile(p); err != nil {
 		return err
 	}
+	if err := fs.chownRecursiveParents(filepath.Dir(p)); err != nil {
+		return err
+	}
 	// Return any remaining error.
 	return err
 }
@@ -189,7 +192,11 @@ func (fs *Filesystem) Write(p string, r io.Reader, newSize int64, mode ufs.FileM
 // CreateDirectory creates a new directory (name) at a specified path (p) for
 // the server.
 func (fs *Filesystem) CreateDirectory(name string, p string) error {
-	return fs.unixFS.MkdirAll(filepath.Join(p, name), 0o755)
+	fullPath := filepath.Join(p, name)
+	if err := fs.unixFS.MkdirAll(fullPath, 0o755); err != nil {
+		return err
+	}
+	return fs.Chown(fullPath)
 }
 
 func (fs *Filesystem) Rename(oldpath, newpath string) error {
@@ -198,6 +205,31 @@ func (fs *Filesystem) Rename(oldpath, newpath string) error {
 
 func (fs *Filesystem) Symlink(oldpath, newpath string) error {
 	return fs.unixFS.Symlink(oldpath, newpath)
+}
+
+// chownRecursiveParents chowns a path and all its parent directories up to the root.
+// This is useful when creating files or directories that may have created new parent dirs.
+func (fs *Filesystem) chownRecursiveParents(p string) error {
+	if fs.isTest {
+		return nil
+	}
+
+	uid := config.Get().System.User.Uid
+	gid := config.Get().System.User.Gid
+
+	current := p
+	for current != "." && current != "" {
+		if err := fs.unixFS.Lchown(current, uid, gid); err != nil {
+			return err
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			break  // Reached root
+		}
+		current = parent
+	}
+
+	return nil
 }
 
 func (fs *Filesystem) chownFile(name string) error {

--- a/server/filesystem/filesystem.go
+++ b/server/filesystem/filesystem.go
@@ -157,6 +157,10 @@ func (fs *Filesystem) Write(p string, r io.Reader, newSize int64, mode ufs.FileM
 		return err
 	}
 
+	// Fetch all directories that are due to be created by Touch so
+	// we can chown them after Touch creates them.
+	createdDirs, _ := fs.pendingDirs(filepath.Dir(p))
+
 	// Touch the file and return the handle to it at this point. This will
 	// create or truncate the file, and create any necessary parent directories
 	// if they are missing.
@@ -182,8 +186,13 @@ func (fs *Filesystem) Write(p string, r io.Reader, newSize int64, mode ufs.FileM
 	if err := fs.chownFile(p); err != nil {
 		return err
 	}
-	if err := fs.chownRecursiveParents(filepath.Dir(p)); err != nil {
-		return err
+
+	// Chown any parent directories that Touch created above so they are owned
+	// by the server user instead of the user Wings runs as.
+	for _, dir := range createdDirs {
+		if err := fs.chownFile(dir); err != nil {
+			return err
+		}
 	}
 	// Return any remaining error.
 	return err
@@ -192,11 +201,23 @@ func (fs *Filesystem) Write(p string, r io.Reader, newSize int64, mode ufs.FileM
 // CreateDirectory creates a new directory (name) at a specified path (p) for
 // the server.
 func (fs *Filesystem) CreateDirectory(name string, p string) error {
-	fullPath := filepath.Join(p, name)
-	if err := fs.unixFS.MkdirAll(fullPath, 0o755); err != nil {
+	// Fetch all directories that are due to be created by MkdirAll so
+	// we can chown them after Touch creates them.
+	createdDirs, _ := fs.pendingDirs(filepath.Join(p, name))
+
+	if err := fs.unixFS.MkdirAll(filepath.Join(p, name), 0o755); err != nil {
 		return err
 	}
-	return fs.Chown(fullPath)
+
+	// Chown any parent directories that MkdirAll created above so they are owned
+	// by the server user instead of the user Wings runs as.
+	for _, dir := range createdDirs {
+		if err := fs.chownFile(dir); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (fs *Filesystem) Rename(oldpath, newpath string) error {
@@ -207,31 +228,6 @@ func (fs *Filesystem) Symlink(oldpath, newpath string) error {
 	return fs.unixFS.Symlink(oldpath, newpath)
 }
 
-// chownRecursiveParents chowns a path and all its parent directories up to the root.
-// This is useful when creating files or directories that may have created new parent dirs.
-func (fs *Filesystem) chownRecursiveParents(p string) error {
-	if fs.isTest {
-		return nil
-	}
-
-	uid := config.Get().System.User.Uid
-	gid := config.Get().System.User.Gid
-
-	current := p
-	for current != "." && current != "" {
-		if err := fs.unixFS.Lchown(current, uid, gid); err != nil {
-			return err
-		}
-		parent := filepath.Dir(current)
-		if parent == current {
-			break  // Reached root
-		}
-		current = parent
-	}
-
-	return nil
-}
-
 func (fs *Filesystem) chownFile(name string) error {
 	if fs.isTest {
 		return nil
@@ -240,6 +236,24 @@ func (fs *Filesystem) chownFile(name string) error {
 	uid := config.Get().System.User.Uid
 	gid := config.Get().System.User.Gid
 	return fs.unixFS.Lchown(name, uid, gid)
+}
+
+// pendingDirs returns the directories along path p that do not yet exist, from
+// deepest to shallowest. It is used to discover exactly which directories a
+// following MkdirAll or Touch will create, so only those can be chowned without
+// re-touching directories that already exist.
+func (fs *Filesystem) pendingDirs(p string) ([]string, error) {
+	var pending []string
+	for cur := filepath.Clean(p); cur != "." && cur != "/" && cur != ""; cur = filepath.Dir(cur) {
+		if _, err := fs.unixFS.Lstat(cur); err == nil {
+			// This directory (and therefore every parent of it) already exists.
+			break
+		} else if !errors.Is(err, ufs.ErrNotExist) {
+			return nil, err
+		}
+		pending = append(pending, cur)
+	}
+	return pending, nil
 }
 
 // Chown recursively iterates over a file or directory and sets the permissions on all of the


### PR DESCRIPTION
Fixes pterodactyl/panel#5646

This pull request improves how file and directory ownership is handled when creating or extracting files and directories in the filesystem. The main changes ensure that ownership (user and group) is correctly set not only on new files, but also for directories.

* Added a new helper method `pendingDirs` to determine which directories along a given path do not exist and will be created, so only these are chowned after creation.
* Updated `Write`, `CreateDirectory`, and directory extraction logic to use `pendingDirs` and chown all newly created directories, ensuring correct ownership.