### PR TITLE
fix: Directories created via panel are owned by root:root

### DIFF
--- a/server/filesystem/compress.go
+++ b/server/filesystem/compress.go
@@ -272,7 +272,7 @@ func (fs *Filesystem) extractStream(ctx context.Context, opts extractStreamOptio
 		// Create directories explicitly; an empty one has no file to create it
 		// implicitly and would otherwise be dropped during extraction.
 		if f.IsDir() {
-			if err := fs.unixFS.MkdirAll(p, 0o755); err != nil {
+			if err := fs.mkdirAll(p, 0o755); err != nil {
 				return wrapError(err, opts.FileName)
 			}
 			return nil

--- a/server/filesystem/filesystem.go
+++ b/server/filesystem/filesystem.go
@@ -240,6 +240,21 @@ func (fs *Filesystem) pendingDirs(p string) ([]string, error) {
 	return pending, nil
 }
 
+// mkdirAll creates the directory p along with any missing parents, then chowns
+// every directory it created to the server user.
+func (fs *Filesystem) mkdirAll(p string, mode ufs.FileMode) error {
+	created, _ := fs.pendingDirs(p)
+	if err := fs.unixFS.MkdirAll(p, mode); err != nil {
+		return err
+	}
+	for _, dir := range created {
+		if err := fs.chownFile(dir); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Chown recursively iterates over a file or directory and sets the permissions on all of the
 // underlying files. Iterate over all of the files and directories. If it is a file just
 // go ahead and perform the chown operation. Otherwise dig deeper into the directory until

--- a/server/filesystem/filesystem.go
+++ b/server/filesystem/filesystem.go
@@ -157,6 +157,10 @@ func (fs *Filesystem) Write(p string, r io.Reader, newSize int64, mode ufs.FileM
 		return err
 	}
 
+	// Fetch all directories that are due to be created by Touch so
+	// we can chown them after Touch creates them.
+	createdDirs, _ := fs.pendingDirs(filepath.Dir(p))
+
 	// Touch the file and return the handle to it at this point. This will
 	// create or truncate the file, and create any necessary parent directories
 	// if they are missing.
@@ -182,6 +186,14 @@ func (fs *Filesystem) Write(p string, r io.Reader, newSize int64, mode ufs.FileM
 	if err := fs.chownFile(p); err != nil {
 		return err
 	}
+
+	// Chown any parent directories that Touch created above so they are owned
+	// by the server user instead of the user Wings runs as.
+	for _, dir := range createdDirs {
+		if err := fs.chownFile(dir); err != nil {
+			return err
+		}
+	}
 	// Return any remaining error.
 	return err
 }
@@ -189,7 +201,7 @@ func (fs *Filesystem) Write(p string, r io.Reader, newSize int64, mode ufs.FileM
 // CreateDirectory creates a new directory (name) at a specified path (p) for
 // the server.
 func (fs *Filesystem) CreateDirectory(name string, p string) error {
-	return fs.unixFS.MkdirAll(filepath.Join(p, name), 0o755)
+	return fs.mkdirAll(filepath.Join(p, name), 0o755)
 }
 
 func (fs *Filesystem) Rename(oldpath, newpath string) error {
@@ -208,6 +220,24 @@ func (fs *Filesystem) chownFile(name string) error {
 	uid := config.Get().System.User.Uid
 	gid := config.Get().System.User.Gid
 	return fs.unixFS.Lchown(name, uid, gid)
+}
+
+// pendingDirs returns the directories along path p that do not yet exist, from
+// deepest to shallowest. It is used to discover exactly which directories a
+// following MkdirAll or Touch will create, so only those can be chowned without
+// re-touching directories that already exist.
+func (fs *Filesystem) pendingDirs(p string) ([]string, error) {
+	var pending []string
+	for cur := filepath.Clean(p); cur != "." && cur != "/" && cur != ""; cur = filepath.Dir(cur) {
+		if _, err := fs.unixFS.Lstat(cur); err == nil {
+			// This directory (and therefore every parent of it) already exists.
+			break
+		} else if !errors.Is(err, ufs.ErrNotExist) {
+			return nil, err
+		}
+		pending = append(pending, cur)
+	}
+	return pending, nil
 }
 
 // Chown recursively iterates over a file or directory and sets the permissions on all of the


### PR DESCRIPTION
### Description

Directories created via panel are owned by the user running the wings daemon. This PR introduces an amendment to chown directories on creation to pterodactyl:pterodactyl, keeping the file system consistent with created files, which are already chowned to the correct user and group.

### Questions or comments

Credits to https://github.com/scru-bb-y for reporting and initial diagnoses of the original issue.

### Resolved issues:
1. [x] resolves pterodactyl/panel#5646